### PR TITLE
fix(leads): show profile pictures on all-leads table load

### DIFF
--- a/src/components/page-builder/LeadTableComponent.tsx
+++ b/src/components/page-builder/LeadTableComponent.tsx
@@ -246,6 +246,13 @@ const transformLeadData = (lead: any, config?: LeadTableProps['config']) => {
     
     // Always include poster field from records JSONB data
     transformedLead.poster = lead.data?.poster || lead.poster || null;
+
+    // Profile avatars in the name column (ShortProfileCard) read row.display_pic_url; API often stores it only on JSONB data
+    transformedLead.display_pic_url =
+      lead.display_pic_url ||
+      lead.data?.display_pic_url ||
+      transformedLead.display_pic_url ||
+      null;
     
     return transformedLead;
   }
@@ -261,6 +268,7 @@ const transformLeadData = (lead: any, config?: LeadTableProps['config']) => {
     whatsapp_link: lead.data?.whatsapp_link || lead.whatsapp_link || '',
     user_profile_link: lead.data?.user_profile_link || lead.user_profile_link || '#',
     poster: lead.data?.poster || lead.poster || null, // Add poster field from records JSONB data
+    display_pic_url: lead.display_pic_url || lead.data?.display_pic_url || null,
   };
 };
 


### PR DESCRIPTION
Populate display_pic_url in transformLeadData from lead.data so ShortProfileCard receives the same avatar URL as the lead detail modal, instead of defaulting until a row is opened.