### PR TITLE
Speed up Lead Groups page by using combined filter options API.

### DIFF
--- a/src/lib/userSettingsApi.ts
+++ b/src/lib/userSettingsApi.ts
@@ -7,6 +7,7 @@ import {
   Group,
   GroupCreatePayload,
   UserCoreKVSetting,
+  LeadFilterOptions,
 } from '../types/userSettings';
 
 const API_BASE_URL = (import.meta.env.VITE_RENDER_API_URL || import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000').replace(/\/+$/, '');
@@ -130,6 +131,32 @@ export const leadTypeAssignmentApi = {
       }
       console.error('Error in getUserLeadTypes:', error);
       throw error;
+    }
+  },
+
+  // All lead filter dropdown values in one request (faster than 4 separate calls).
+  async getLeadFilterOptions(endpoint?: string): Promise<LeadFilterOptions> {
+    const empty: LeadFilterOptions = {
+      lead_types: [],
+      lead_sources: [],
+      lead_statuses: [],
+      lead_states: [],
+    };
+
+    try {
+      const filterOptionsEndpoint = endpoint || '/user-settings/lead-filter-options/';
+      const response = await apiClient.get(filterOptionsEndpoint);
+      const responseData = response.data;
+
+      return {
+        lead_types: Array.isArray(responseData.lead_types) ? responseData.lead_types : [],
+        lead_sources: Array.isArray(responseData.lead_sources) ? responseData.lead_sources : [],
+        lead_statuses: Array.isArray(responseData.lead_statuses) ? responseData.lead_statuses : [],
+        lead_states: Array.isArray(responseData.lead_states) ? responseData.lead_states : [],
+      };
+    } catch (error: any) {
+      console.error('Error fetching lead filter options:', error);
+      return empty;
     }
   },
 

--- a/src/pages/LeadGroupsPage.tsx
+++ b/src/pages/LeadGroupsPage.tsx
@@ -156,21 +156,18 @@ const LeadGroupsPage: React.FC<LeadGroupsPageProps> = ({ className = "", showHea
 
   const loadData = async () => {
     try {
-      const [groupsData, usersData, sourcesData, statusesData, statesData, partiesData, queueTypesData] = await Promise.all([
+      const [groupsData, usersData, filterOptions, queueTypesData] = await Promise.all([
         groupsApi.getAll(),
         leadTypeAssignmentApi.getAll(),
-        leadTypeAssignmentApi.getAvailableLeadSources(),
-        leadTypeAssignmentApi.getAvailableLeadStatuses(),
-        leadTypeAssignmentApi.getAvailableLeadStates(),
-        leadTypeAssignmentApi.getAvailableLeadTypes(),
+        leadTypeAssignmentApi.getLeadFilterOptions(),
         leadTypeAssignmentApi.getAvailableQueueTypes(),
       ]);
       setGroups(groupsData);
       setUsers(usersData);
-      setLeadSources(sourcesData);
-      setLeadStatuses(statusesData);
-      setLeadStates(statesData);
-      setParties(partiesData);
+      setLeadSources(filterOptions.lead_sources);
+      setLeadStatuses(filterOptions.lead_statuses);
+      setLeadStates(filterOptions.lead_states);
+      setParties(filterOptions.lead_types);
       setQueueTypes(queueTypesData);
     } catch (error: any) {
       toast.error(`Failed to load lead groups data: ${error.message}`);

--- a/src/types/userSettings.ts
+++ b/src/types/userSettings.ts
@@ -30,6 +30,13 @@ export interface UserLeadTypes {
 // No hardcoded lead types - they are fetched from the backend
 export type LeadType = string;
 
+export interface LeadFilterOptions {
+  lead_types: string[];
+  lead_sources: string[];
+  lead_statuses: string[];
+  lead_states: string[];
+}
+
 // API Response Types
 export interface ApiResponse<T> {
   success: boolean;


### PR DESCRIPTION
Replace four parallel dropdown requests with one lead-filter-options call to match backend query optimizations.