### PR TITLE
Route ticket tables to renderer by default and surface API Prefix.

### DIFF
--- a/src/component-config/TableConfig.tsx
+++ b/src/component-config/TableConfig.tsx
@@ -76,6 +76,8 @@ export interface ColumnConfig {
 interface TableConfigProps {
   localConfig: {
     apiEndpoint: string;
+    /** Base host: supabase edge functions vs pyro-backend renderer. */
+    apiPrefix?: 'supabase' | 'renderer';
     showFilters: boolean;
     searchFields?: string;
     entityType?: string;
@@ -154,6 +156,24 @@ export const TableConfig: React.FC<TableConfigProps> = ({
 
   return (
     <div className="space-y-4">
+      <div>
+        <Label>API Prefix</Label>
+        <Select
+          value={localConfig.apiPrefix || 'renderer'}
+          onValueChange={(value) => handleInputChange('apiPrefix', value)}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Select API Prefix" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="supabase">Supabase</SelectItem>
+            <SelectItem value="renderer">Renderer</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground mt-1">
+          Use Renderer for pyro-backend routes (e.g. /support-ticket/…)
+        </p>
+      </div>
       <div>
         <Label>API Endpoint</Label>
         <Input

--- a/src/components/page-builder/TicketTableComponent.tsx
+++ b/src/components/page-builder/TicketTableComponent.tsx
@@ -295,7 +295,9 @@ export const TicketTableComponent: React.FC<TicketTableProps> = ({ config }) => 
     startTime: '00:00',
     endTime: '23:59'
   });
-  const [apiPrefix, setApiPrefix] = useState<'supabase' | 'renderer'>(config?.apiPrefix || 'supabase');
+  const [apiPrefix, setApiPrefix] = useState<'supabase' | 'renderer'>(
+    config?.apiPrefix || 'renderer'
+  );
   const [filtersApplied, setFiltersApplied] = useState(false);
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [displaySearchTerm, setDisplaySearchTerm] = useState<string>(''); // Separate state for display
@@ -1305,8 +1307,13 @@ export const TicketTableComponent: React.FC<TicketTableProps> = ({ config }) => 
         const authToken = session?.access_token;
 
         const endpoint = config?.apiEndpoint || '/api/tickets';
-        const baseUrl = apiPrefix === 'renderer' 
-          ? TICKET_API_BASE 
+        // Page builder uses TableConfig for ticketTable (no apiPrefix UI). Support
+        // ticket APIs live on the renderer backend, not Supabase edge functions.
+        const useRenderer =
+          apiPrefix === 'renderer' ||
+          endpoint.includes('/support-ticket/');
+        const baseUrl = useRenderer
+          ? TICKET_API_BASE
           : import.meta.env.VITE_API_URI;
         const apiUrl = `${baseUrl}${endpoint}?page=1&page_size=50`;
         console.log('API URL:', apiUrl);
@@ -1402,7 +1409,16 @@ export const TicketTableComponent: React.FC<TicketTableProps> = ({ config }) => 
           console.log('Reapplying filters after data fetch...');
           setTimeout(() => applyFilters(), 100); // Small delay to ensure state is updated
         }
-      } catch (error) {
+      } catch (error: any) {
+        // Effect re-runs (token/config) abort the previous fetch — not a real failure.
+        if (
+          error?.name === 'AbortError' ||
+          abortController.signal.aborted ||
+          (typeof error?.message === 'string' &&
+            error.message.toLowerCase().includes('aborted'))
+        ) {
+          return;
+        }
         console.error('Error fetching tickets:', error);
         // Set empty data on error instead of using demo data
         setData([]);
@@ -1413,7 +1429,9 @@ export const TicketTableComponent: React.FC<TicketTableProps> = ({ config }) => 
           console.log('Filters were applied but data fetch failed');
         }
       } finally {
-        setLoading(false);
+        if (!abortController.signal.aborted) {
+          setLoading(false);
+        }
       }
     };
 

--- a/src/components/page-builder/component-config/TicketTableConfig.tsx
+++ b/src/components/page-builder/component-config/TicketTableConfig.tsx
@@ -63,7 +63,7 @@ export const TicketTableConfig: React.FC<TicketTableConfigProps> = ({
         <div className="space-y-2">
           <Label htmlFor="apiPrefix">API Prefix</Label>
           <Select
-            value={localConfig.apiPrefix || "supabase"}
+            value={localConfig.apiPrefix || "renderer"}
             onValueChange={(value) => handleInputChange("apiPrefix", value)}
           >
             <SelectTrigger>
@@ -75,7 +75,7 @@ export const TicketTableConfig: React.FC<TicketTableConfigProps> = ({
             </SelectContent>
           </Select>
           <p className="text-xs text-muted-foreground">
-            Choose the API service to use for fetching data
+            Use Renderer for pyro-backend routes (e.g. get-wip-tickets, get-not-connected-tickets)
           </p>
         </div>
 


### PR DESCRIPTION
Support-ticket list endpoints only exist on pyro-backend; ignore AbortError from effect cleanup so remounts do not clear the table.