### PR TITLE
Show CSE daily target as resolve-rate percentage in settings and PDF.

### DIFF
--- a/src/components/page-builder/AddUserComponent.tsx
+++ b/src/components/page-builder/AddUserComponent.tsx
@@ -72,6 +72,14 @@ interface RowEditState {
   managerEmail: string;
 }
 
+/** CSE daily target is a resolve-rate goal expressed as a percentage. */
+function formatResolveRateGoal(value?: string | number): string {
+  if (value === undefined || value === null || value === '—' || value === '') {
+    return '—';
+  }
+  return `${value}%`;
+}
+
 function SupportDailyDualDisplay({
   selfTrial,
   other,
@@ -1338,7 +1346,7 @@ const AddUserComponent: React.FC = () => {
                               />
                             )
                           ) : rowIsCse ? (
-                            <>{user.supportResolveRateGoal ?? '—'}</>
+                            <>{formatResolveRateGoal(user.supportResolveRateGoal)}</>
                           ) : (
                             user.dailyTarget
                           )}

--- a/src/lib/usersReportPdf.ts
+++ b/src/lib/usersReportPdf.ts
@@ -15,6 +15,26 @@ export interface UsersReportRow {
   department?: string;
   role?: { name?: string } | null;
   created_at: string;
+  /** CSE daily target is a resolve-rate goal (%); others use a count-based daily target. */
+  supportResolveRateGoal?: string | number;
+  dailyTarget?: string | number;
+}
+
+function isCseRoleName(name?: string): boolean {
+  const upper = (name ?? '').toUpperCase();
+  return upper.includes('CSE') || upper.includes('CUSTOMER SUPPORT');
+}
+
+function isBlankValue(value?: string | number): boolean {
+  return value === undefined || value === null || value === '—' || value === '';
+}
+
+/** CSE rows show the resolve-rate goal as a percentage; everyone else the daily target. */
+function formatTargetForReport(row: UsersReportRow): string {
+  if (isCseRoleName(row.role?.name)) {
+    return isBlankValue(row.supportResolveRateGoal) ? '—' : `${row.supportResolveRateGoal}%`;
+  }
+  return isBlankValue(row.dailyTarget) ? '—' : String(row.dailyTarget);
 }
 
 const IST_OFFSET_MS = 5.5 * 60 * 60 * 1000;
@@ -69,12 +89,13 @@ export async function downloadUsersReportPdf(users: UsersReportRow[]) {
     doc.text(`Total users: ${rows.length}`, marginX, topMarginY + 16);
 
     autoTable(doc, {
-      head: [['Name', 'Email', 'Department', 'Role', 'Created At']],
+      head: [['Name', 'Email', 'Department', 'Role', 'Target', 'Created At']],
       body: rows.map((user) => [
         user.name,
         user.email,
         user.department || '—',
         user.role?.name || 'No Role',
+        formatTargetForReport(user),
         formatCreatedAt(user.created_at),
       ]),
       startY: topMarginY + 24,


### PR DESCRIPTION
The CSE daily target is a resolve-rate goal (%), so render it with a % suffix in the users settings table and add a Target column to the users report PDF.