### PR TITLE
Gate inventory Approve/Reject to managers and Order to team leads.

### DIFF
--- a/src/component-config/TableConfig.tsx
+++ b/src/component-config/TableConfig.tsx
@@ -100,6 +100,8 @@ interface TableConfigProps {
     paymentModalConfig?: PaymentModalConfig;
     /** Show Save button in form-style record modal footer (in addition to any action buttons). */
     showFormModalSaveButton?: boolean;
+    /** manager = Approve/Reject; team_lead = Order only; auto = from role. */
+    inventoryWorkflowMode?: 'auto' | 'manager' | 'team_lead';
     /** Form-style modal: show the extra “Final price” block (computed from quantity). Default on when omitted. */
     showFinalPriceSection?: boolean;
     /** Default record detail modal: show requestor-side Delete request button. Default off. */
@@ -260,13 +262,41 @@ export const TableConfig: React.FC<TableConfigProps> = ({
       </div>
 
       {isInventoryProfile ? (
-        <div className="rounded-md border border-border/60 bg-muted/30 p-3 space-y-2">
-          <p className="text-sm font-medium">Inventory request flow</p>
-          <p className="text-xs text-muted-foreground">
-            Built-in modal actions (on existing statuses): Approve/Reject on NEW_REQUEST/DRAFT/PENDING_PM → VENDOR_IDENTIFIED;
-            team lead Order on VENDOR_IDENTIFIED/PAYMENT_PENDING → IN_SHIPPING; then paste shipment tracking.
-            Extra Status action buttons below are optional.
-          </p>
+        <div className="rounded-md border border-border/60 bg-muted/30 p-3 space-y-3">
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Inventory request flow</p>
+            <p className="text-xs text-muted-foreground">
+              Manager pages: Approve/Reject on NEW_REQUEST/DRAFT/PENDING_PM. Team-lead pages: Order only on
+              VENDOR_IDENTIFIED/PAYMENT_PENDING (no Approve/Reject on new requests).
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label>All Requests actor</Label>
+            <Select
+              value={
+                localConfig.inventoryWorkflowMode === 'manager' ||
+                localConfig.inventoryWorkflowMode === 'team_lead'
+                  ? localConfig.inventoryWorkflowMode
+                  : 'auto'
+              }
+              onValueChange={(value: 'auto' | 'manager' | 'team_lead') =>
+                handleInputChange('inventoryWorkflowMode', value)
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Auto (from role)" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="auto">Auto (from user role)</SelectItem>
+                <SelectItem value="manager">Manager — Approve / Reject</SelectItem>
+                <SelectItem value="team_lead">Team lead — Order only</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Set <strong>Team lead — Order only</strong> on the team-lead All Requests page so new requests never
+              show Approve/Reject.
+            </p>
+          </div>
           <Button type="button" variant="outline" size="sm" onClick={applySimpleInventoryDefaults}>
             Reset inventory form defaults
           </Button>

--- a/src/components/page-builder/InventoryFormEditModal.tsx
+++ b/src/components/page-builder/InventoryFormEditModal.tsx
@@ -104,6 +104,13 @@ interface InventoryFormEditModalProps {
   formModalDescription?: string;
   /** Whether to show the Save button in the footer. If undefined, Save shows only when there are no action buttons. */
   showSaveButton?: boolean;
+  /**
+   * Inventory All Requests actor:
+   * - manager → Approve / Reject only
+   * - team_lead → Order only (no Approve / Reject on new requests)
+   * - auto → infer from membership role
+   */
+  inventoryWorkflowMode?: 'auto' | 'manager' | 'team_lead';
   /** When set, show one button: conditional if attribute matches, else default (e.g. Inventory Payment modal). */
   paymentButtonConfig?: {
     conditionalButton: { attribute: string; operator: 'gt' | 'lt' | 'gte' | 'lte'; value: string | number; label: string; statusValue: string; targetAttribute?: string };
@@ -209,6 +216,7 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
   formModalTitle,
   formModalDescription: _formModalDescription,
   showSaveButton,
+  inventoryWorkflowMode,
   paymentButtonConfig,
   modalFlags,
   showFinalPriceSection,
@@ -1072,11 +1080,12 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
   const usePaymentButtons = paymentButtonConfig?.conditionalButton && paymentButtonConfig?.defaultButton;
   const statusFromForm =
     formData.status != null && String(formData.status).trim() !== '' ? formData.status : undefined;
+  // Prefer saved record status for Approve / Reject / Order so a mismatched status
+  // dropdown (e.g. NEW_REQUEST not in options) cannot hide the workflow buttons.
   const requestStatusForWorkflow =
-    statusFromForm ??
     (record?.data && typeof record.data === 'object'
       ? (record.data as Record<string, unknown>).status
-      : undefined);
+      : undefined) ?? statusFromForm;
   const teamLeadFromForm =
     formData.team_lead != null && String(formData.team_lead).trim() !== ''
       ? formData.team_lead
@@ -1096,6 +1105,7 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
           membershipId: myMembershipId,
           teamLeadOnRecord,
           isRequester,
+          workflowMode: inventoryWorkflowMode ?? 'auto',
         })
       : [];
 

--- a/src/components/page-builder/InventoryTableComponent.tsx
+++ b/src/components/page-builder/InventoryTableComponent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { LeadTableComponent } from './LeadTableComponent';
 import { mergeInventoryTrackingColumns } from '@/lib/shipmentTracking';
 
@@ -16,8 +16,10 @@ interface RecordsTableProps {
  * Generic records table component for PageBuilder.
  * Backed by LeadTableComponent but not tied to any specific entity.
  *
- * For inventory_request tables, shipment tracking columns (Shipment / Track / ETA / Courier)
- * are merged in when missing so All Requests pages show live tracking without reconfig.
+ * For inventory_request tables:
+ * - shipment tracking columns are merged when missing
+ * - row click opens the form modal so built-in Approve / Reject / Order show
+ *   (same as Procurement Table / Manager All Requests)
  */
 export const InventoryTableComponent: React.FC<RecordsTableProps> = ({ config }) => {
   const entityType = String(config?.entityType || '').trim();
@@ -26,10 +28,18 @@ export const InventoryTableComponent: React.FC<RecordsTableProps> = ({ config })
     ? mergeInventoryTrackingColumns(config?.columns)
     : config?.columns;
 
+  const detailMode = config?.detailMode;
+  const keepSpecial =
+    detailMode === 'inventory_payment_modal' ||
+    detailMode === 'receive_shipments' ||
+    detailMode === 'lead_assignment_modal' ||
+    detailMode === 'none';
+
   const mergedConfig = {
     title: config?.title || '',
     ...(config || {}),
     ...(columns ? { columns } : {}),
+    ...(isInventoryRequest && !keepSpecial ? { detailMode: 'record_form_modal' } : {}),
   };
 
   return <LeadTableComponent config={mergedConfig} />;

--- a/src/components/page-builder/LeadTableComponent.tsx
+++ b/src/components/page-builder/LeadTableComponent.tsx
@@ -405,6 +405,11 @@ interface LeadTableProps {
     };
     /** Show Save button in form-style modal footer. If undefined, Save shows only when there are no action buttons. */
     showFormModalSaveButton?: boolean;
+    /**
+     * Inventory All Requests actor for built-in modal buttons.
+     * manager = Approve/Reject; team_lead = Order only; auto = from role.
+     */
+    inventoryWorkflowMode?: 'auto' | 'manager' | 'team_lead';
     /** Form-style modal: show the extra “Final price” computed block. Default true when omitted. */
     showFinalPriceSection?: boolean;
     /** Default modal: show requestor-side "Delete request" action. Default false. */
@@ -2592,6 +2597,7 @@ export const LeadTableComponent: React.FC<LeadTableProps> = ({ config, pageId })
           actionButtons={effectiveDetailMode === 'inventory_payment_modal' ? undefined : config?.statusButtons}
           paymentButtonConfig={effectiveDetailMode === 'inventory_payment_modal' ? config?.paymentModalConfig : undefined}
           showSaveButton={config?.showFormModalSaveButton}
+          inventoryWorkflowMode={config?.inventoryWorkflowMode}
           showFinalPriceSection={config?.showFinalPriceSection}
           modalFlags={config?.modalFlags}
           cartOptions={config?.entityType === 'inventory_request' ? cartOptions : undefined}

--- a/src/components/page-builder/ProcurementTableComponent.tsx
+++ b/src/components/page-builder/ProcurementTableComponent.tsx
@@ -59,6 +59,18 @@ export const DEFAULT_PROCUREMENT_TABLE_CONFIG = {
   tableType: 'itemsTable' as const,
   // Form modal hosts built-in Approve / Reject / Order (Record detail does not).
   detailMode: 'record_form_modal' as const,
+  showFinalPriceSection: false,
+  formModalFields: [
+    { key: 'status', label: 'Status', enabled: false },
+    { key: 'item_name_freeform', label: 'Item', enabled: false },
+    { key: 'quantity_required', label: 'Quantity', enabled: true },
+    { key: 'vendor', label: 'Vendor', enabled: true },
+    { key: 'urgency_level', label: 'Urgency', enabled: true },
+    { key: 'department', label: 'Department', enabled: false },
+    { key: 'specifications', label: 'Specifications', enabled: true },
+    { key: 'product_link', label: 'Product link', enabled: true, link: true },
+    { key: 'comments', label: 'Comments', enabled: true },
+  ],
 };
 
 function withPriorityTransform(columns: ProcurementTableColumn[]): ProcurementTableColumn[] {
@@ -91,22 +103,27 @@ function entityTypeFromEndpoint(apiEndpoint?: string): string | undefined {
 }
 
 /**
- * Resolve row-click modal so Approve / Order appear on procurement All Requests.
- * Older pages use record_form_modal; this component previously defaulted to
- * inventory_request (RecordDetailModal), which has no workflow action buttons.
+ * Resolve row-click modal so Approve / Reject / Order appear on Manager & TL All Requests.
+ * Always use the form modal for inventory-like tables unless an explicit special mode is set.
  */
 function resolveProcurementDetailMode(
   detailMode: ProcurementTableConfig['detailMode'] | undefined,
   isInventoryLike: boolean
 ): ProcurementTableConfig['detailMode'] | undefined {
-  if (!detailMode || detailMode === 'auto') {
-    return isInventoryLike ? 'record_form_modal' : undefined;
+  if (!isInventoryLike) return detailMode;
+
+  // Keep intentional special modes.
+  if (
+    detailMode === 'inventory_payment_modal' ||
+    detailMode === 'receive_shipments' ||
+    detailMode === 'lead_assignment_modal' ||
+    detailMode === 'none'
+  ) {
+    return detailMode;
   }
-  // Map legacy default to the form modal that owns Approve / Order.
-  if (detailMode === 'inventory_request') {
-    return 'record_form_modal';
-  }
-  return detailMode;
+
+  // auto / inventory_request / lead_card / unset → form modal with Approve / Reject / Order.
+  return 'record_form_modal';
 }
 
 /**
@@ -127,18 +144,28 @@ export const ProcurementTableComponent: React.FC<ProcurementTableProps> = ({ con
     );
     const detailMode = resolveProcurementDetailMode(config?.detailMode, isInventoryLike);
 
+    const { detailMode: _ignoredDetailMode, ...restConfig } = config || {};
+    const tableType: 'default' | 'itemsTable' =
+      restConfig.tableType === 'default' ? 'default' : 'itemsTable';
+
     return {
-      ...(config || {}),
+      ...restConfig,
       columns,
       entityType,
-      tableType: config?.tableType || 'itemsTable',
+      tableType,
       detailMode,
+      // Ensure Manager All Requests always has form fields for the Approve/Reject modal.
+      formModalFields:
+        Array.isArray(config?.formModalFields) && config.formModalFields.length > 0
+          ? config.formModalFields
+          : DEFAULT_PROCUREMENT_TABLE_CONFIG.formModalFields,
+      showFinalPriceSection: config?.showFinalPriceSection ?? false,
       // If someone still uses inventory_request/inventory_cart modes, force form_edit.
       ...(detailMode === 'inventory_request' || detailMode === 'inventory_cart'
         ? { recordDetailModalType: config?.recordDetailModalType ?? 'form_edit' }
         : {}),
-    };
+    } as Record<string, unknown>;
   }, [config]);
 
-  return <LeadTableComponent config={mergedConfig} />;
+  return <LeadTableComponent config={mergedConfig as any} />;
 };

--- a/src/constants/inventory.ts
+++ b/src/constants/inventory.ts
@@ -1,5 +1,6 @@
 /** Canonical inventory request statuses used in all dropdowns and filters. */
 export const INVENTORY_REQUEST_STATUSES = [
+  'NEW_REQUEST',
   'DRAFT',
   'PENDING_PM',
   'VENDOR_IDENTIFIED',

--- a/src/lib/inventoryWorkflow.test.ts
+++ b/src/lib/inventoryWorkflow.test.ts
@@ -13,35 +13,81 @@ describe('inventory procurement → order flow (existing statuses)', () => {
       getInventoryWorkflowButtons({
         requestStatus: 'PENDING_PM',
         isRequester: true,
+        workflowMode: 'manager',
       })
     ).toEqual([]);
     expect(
       getInventoryWorkflowButtons({
         requestStatus: 'VENDOR_IDENTIFIED',
         isRequester: true,
+        workflowMode: 'team_lead',
       })
     ).toEqual([]);
   });
 
-  it('non-requestor can Approve/Reject on PENDING_PM, DRAFT, and NEW_REQUEST', () => {
+  it('manager can Approve/Reject on PENDING_PM, DRAFT, and NEW_REQUEST', () => {
     for (const status of ['PENDING_PM', 'DRAFT', 'NEW_REQUEST']) {
       const buttons = getInventoryWorkflowButtons({
         requestStatus: status,
         isRequester: false,
+        workflowMode: 'manager',
       });
       expect(buttons.map((b) => b.statusValue)).toEqual(['VENDOR_IDENTIFIED', 'REJECTED']);
     }
   });
 
-  it('non-requestor sees Order on VENDOR_IDENTIFIED and PAYMENT_PENDING (no role required)', () => {
+  it('team lead never sees Approve/Reject on new requests', () => {
+    for (const status of ['PENDING_PM', 'DRAFT', 'NEW_REQUEST']) {
+      expect(
+        getInventoryWorkflowButtons({
+          requestStatus: status,
+          isRequester: false,
+          workflowMode: 'team_lead',
+          roleNameOrKey: 'Team Lead',
+        })
+      ).toEqual([]);
+    }
+  });
+
+  it('team lead sees Order on VENDOR_IDENTIFIED / PAYMENT_PENDING', () => {
     for (const status of ['VENDOR_IDENTIFIED', 'VENDOR IDENTIFIED', 'PAYMENT_PENDING']) {
       const buttons = getInventoryWorkflowButtons({
         requestStatus: status,
-        roleNameOrKey: 'engineer',
+        roleNameOrKey: 'Team Lead',
+        workflowMode: 'team_lead',
         isRequester: false,
       });
       expect(buttons.map((b) => [b.label, b.statusValue])).toEqual([['Order', 'IN_SHIPPING']]);
     }
+  });
+
+  it('manager does not see Order (team-lead-only action)', () => {
+    expect(
+      getInventoryWorkflowButtons({
+        requestStatus: 'VENDOR_IDENTIFIED',
+        workflowMode: 'manager',
+        isRequester: false,
+      })
+    ).toEqual([]);
+  });
+
+  it('auto mode: team-lead role hides Approve; procurement role shows Approve', () => {
+    expect(
+      getInventoryWorkflowButtons({
+        requestStatus: 'NEW_REQUEST',
+        roleNameOrKey: 'CSE Team Lead',
+        isRequester: false,
+        workflowMode: 'auto',
+      })
+    ).toEqual([]);
+    expect(
+      getInventoryWorkflowButtons({
+        requestStatus: 'NEW_REQUEST',
+        roleNameOrKey: 'Procurement Manager',
+        isRequester: false,
+        workflowMode: 'auto',
+      }).map((b) => b.label)
+    ).toEqual(['Approve', 'Reject']);
   });
 
   it('recognizes procurement vs team-lead roles', () => {

--- a/src/lib/inventoryWorkflow.ts
+++ b/src/lib/inventoryWorkflow.ts
@@ -2,14 +2,16 @@
  * Inventory request flow on the existing status architecture:
  *
  *   NEW_REQUEST / DRAFT / PENDING_PM
- *     → (non-requestor Approve) VENDOR_IDENTIFIED
- *     → (Reject) REJECTED
+ *     → (manager Approve) VENDOR_IDENTIFIED
+ *     → (manager Reject) REJECTED
  *   VENDOR_IDENTIFIED / PAYMENT_PENDING
- *     → (non-requestor Order) IN_SHIPPING
+ *     → (team lead Order) IN_SHIPPING
  *   IN_SHIPPING+ → shipment tracking (paste link/AWB)
  *
- * Team-lead / hierarchy is used for assignment & notifications; Order is not
- * blocked on role-name matching (that caused Save-only on TL pages).
+ * Page Builder can set inventoryWorkflowMode:
+ *   - manager   → Approve / Reject only
+ *   - team_lead → Order only (no Approve / Reject on new requests)
+ *   - auto      → infer from membership role
  */
 
 export const INVENTORY_APPROVABLE_STATUSES = new Set([
@@ -30,6 +32,8 @@ export const INVENTORY_WORKFLOW_BUILTIN_STATUS_VALUES = new Set([
   'REJECTED',
   'IN_SHIPPING',
 ]);
+
+export type InventoryWorkflowMode = 'auto' | 'manager' | 'team_lead';
 
 export type InventoryWorkflowActionButton = {
   label: string;
@@ -96,12 +100,27 @@ export function isAssignedInventoryTeamLead(
   return false;
 }
 
+function resolveWorkflowMode(opts: {
+  workflowMode?: InventoryWorkflowMode | null;
+  roleNameOrKey?: string | null;
+  roleKey?: string | null;
+}): 'manager' | 'team_lead' {
+  if (opts.workflowMode === 'manager' || opts.workflowMode === 'team_lead') {
+    return opts.workflowMode;
+  }
+  const roles = [opts.roleNameOrKey, opts.roleKey];
+  if (roles.some((r) => isInventoryTeamLeadRole(r))) return 'team_lead';
+  if (roles.some((r) => isInventoryProcurementRole(r))) return 'manager';
+  // Unknown role: default to manager-style approve (safe for Manager All Requests).
+  // Team-lead pages should set inventoryWorkflowMode=team_lead in Page Builder.
+  return 'manager';
+}
+
 /**
  * Built-in Approve / Reject / Order for the record form modal.
  *
- * Approve/Reject: anyone except the requestor on NEW_REQUEST/DRAFT/PENDING_PM.
- * Order: anyone except the requestor on VENDOR_IDENTIFIED/PAYMENT_PENDING
- *   (team-lead pages filter the list; role/hierarchy matching was too brittle).
+ * Manager: Approve/Reject on NEW_REQUEST/DRAFT/PENDING_PM.
+ * Team lead: Order on VENDOR_IDENTIFIED/PAYMENT_PENDING (never Approve/Reject).
  */
 export function getInventoryWorkflowButtons(opts: {
   requestStatus: unknown;
@@ -111,6 +130,8 @@ export function getInventoryWorkflowButtons(opts: {
   userId?: number | string | null;
   teamLeadOnRecord?: unknown;
   isRequester?: boolean;
+  /** Page-level override: manager All Requests vs team-lead All Requests. */
+  workflowMode?: InventoryWorkflowMode | null;
 }): InventoryWorkflowActionButton[] {
   const status = normalizeStatus(opts.requestStatus);
   const buttons: InventoryWorkflowActionButton[] = [];
@@ -119,7 +140,9 @@ export function getInventoryWorkflowButtons(opts: {
     return buttons;
   }
 
-  if (INVENTORY_APPROVABLE_STATUSES.has(status)) {
+  const mode = resolveWorkflowMode(opts);
+
+  if (mode === 'manager' && INVENTORY_APPROVABLE_STATUSES.has(status)) {
     buttons.push(
       {
         label: 'Approve',
@@ -130,7 +153,7 @@ export function getInventoryWorkflowButtons(opts: {
     );
   }
 
-  if (INVENTORY_ORDERABLE_STATUSES.has(status)) {
+  if (mode === 'team_lead' && INVENTORY_ORDERABLE_STATUSES.has(status)) {
     buttons.push({
       label: 'Order',
       statusValue: 'IN_SHIPPING',

--- a/src/pages/PageBuilder.tsx
+++ b/src/pages/PageBuilder.tsx
@@ -397,6 +397,8 @@ const ConfigurationPanel: React.FC<ConfigurationPanelProps> = ({ selectedCompone
     formModalDescription?: string;
     paymentModalConfig?: import('@/component-config').PaymentModalConfig;
     showFormModalSaveButton?: boolean;
+    /** manager = Approve/Reject; team_lead = Order only; auto = from role. */
+    inventoryWorkflowMode?: 'auto' | 'manager' | 'team_lead';
     /** Form-style modal: show extra “Final price” block. Default true when omitted. */
     showFinalPriceSection?: boolean;
     /** Requestor-side Delete request (any status when on). Default false. */
@@ -471,6 +473,7 @@ const ConfigurationPanel: React.FC<ConfigurationPanelProps> = ({ selectedCompone
     formModalDescription: (initialConfig as any).formModalDescription ?? '',
     paymentModalConfig: (initialConfig as any).paymentModalConfig ?? undefined,
     showFormModalSaveButton: (initialConfig as any).showFormModalSaveButton ?? undefined,
+    inventoryWorkflowMode: (initialConfig as any).inventoryWorkflowMode ?? 'auto',
     showFinalPriceSection: (initialConfig as any).showFinalPriceSection ?? undefined,
     showDeleteRequestButton: (initialConfig as any).showDeleteRequestButton ?? false,
     showHistoryButton: (initialConfig as any).showHistoryButton ?? false,


### PR DESCRIPTION
Force All Requests tables onto the form modal, and add a Page Builder actor mode so team-lead pages never show Approve/Reject on new requests.