### PR TITLE
Show full shipment route and scan history from live tracking.

### DIFF
--- a/src/components/page-builder/InventoryFormEditModal.tsx
+++ b/src/components/page-builder/InventoryFormEditModal.tsx
@@ -41,6 +41,10 @@ import {
   advanceShipmentStatusForTracking,
   shouldShowShipmentTrackingSection,
   fetchLiveShipmentStatus,
+  shipmentDetailsFromTrackResult,
+  publicTrackingLink,
+  normalizeCourierLabel,
+  type ShipmentTrackDetails,
 } from '@/lib/shipmentTracking';
 import {
   filterDuplicateInventoryWorkflowButtons,
@@ -253,6 +257,7 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
   const [myMembershipId, setMyMembershipId] = useState<number | null>(null);
   const [trackingLiveLoading, setTrackingLiveLoading] = useState(false);
   const [trackingStatusDetail, setTrackingStatusDetail] = useState<string | null>(null);
+  const [trackingDetails, setTrackingDetails] = useState<ShipmentTrackDetails | null>(null);
 
   const myName =
     user?.user_metadata?.full_name || user?.user_metadata?.name || user?.email || '—';
@@ -305,15 +310,48 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
 
   const applyLiveTrackingResult = useCallback(
     (result: Awaited<ReturnType<typeof fetchLiveShipmentStatus>>) => {
+      console.log('[shipment-track] apply result to form', {
+        ok: result.ok,
+        incomingStatus: result.shipment_status,
+        statusDetail: result.status_detail,
+        error: result.error,
+        method: result.method,
+        courier: result.courier_name,
+      });
       if (result.tracking_number) setField('tracking_number', result.tracking_number);
-      if (result.tracking_link) setField('tracking_link', result.tracking_link);
-      if (result.courier_name) setField('courier_name', result.courier_name);
+      // Always fill tracking link when the user only pasted an AWB.
+      if (result.tracking_link) {
+        setField('tracking_link', result.tracking_link);
+      } else if (result.tracking_number) {
+        const synthesized = publicTrackingLink(result.tracking_number, result.courier_name);
+        if (synthesized) setField('tracking_link', synthesized);
+      }
+      // Only overwrite courier on a confirmed live hit.
+      if (result.ok === true && result.courier_name) {
+        const label = normalizeCourierLabel(result.courier_name) || String(result.courier_name);
+        setField('courier_name', label);
+      }
       if (result.eta) setField('eta', String(result.eta).slice(0, 10));
-      if (result.shipment_status) setField('shipment_status', result.shipment_status);
       setTrackingStatusDetail(
         result.status_detail ||
           (result.ok === false && result.error ? result.error : null)
       );
+      setTrackingDetails(shipmentDetailsFromTrackResult(result));
+      // Soft / pending failures must not move the pipeline.
+      if (result.ok === false) {
+        console.warn('[shipment-track] live track not confirmed — pipeline left unchanged', {
+          error: result.error,
+          statusDetail: result.status_detail,
+        });
+        return;
+      }
+      if (!result.shipment_status) {
+        console.warn('[shipment-track] no shipment_status in response — pipeline unchanged');
+        return;
+      }
+      const incoming = String(result.shipment_status).trim().toUpperCase().replace(/\s+/g, '_');
+      console.log('[shipment-track] setting pipeline (ok)', incoming);
+      setField('shipment_status', incoming);
     },
     [setField]
   );
@@ -356,14 +394,12 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
         }
       } catch (err) {
         console.error('Live shipment track failed', err);
-        // Still advance to ORDERED so the pipeline is not blank.
-        const fallback = advanceShipmentStatusForTracking(formData.shipment_status, true);
-        if (fallback) setField('shipment_status', fallback);
-        setTrackingStatusDetail('Could not reach live tracking. Pipeline set from tracking id.');
+        setTrackingStatusDetail('Live tracking timed out. Try Refresh again in a moment.');
+        // Keep any previously loaded route/events on timeout.
         if (!overrides?.silent) {
           toast({
-            title: 'Live tracking failed',
-            description: 'Could not fetch carrier status. Check the number/link and try Refresh.',
+            title: 'Live tracking timed out',
+            description: 'Could not reach the carrier in time. Try Refresh again.',
             variant: 'destructive',
           });
         }
@@ -371,7 +407,7 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
         setTrackingLiveLoading(false);
       }
     },
-    [formData.tracking_number, formData.tracking_link, formData.courier_name, formData.shipment_status, applyLiveTrackingResult, setField, toast]
+    [formData.tracking_number, formData.tracking_link, formData.courier_name, formData.shipment_status, applyLiveTrackingResult, toast]
   );
 
   const applyTrackingPaste = useCallback(
@@ -379,9 +415,14 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
       const paste = raw.trim();
       if (!paste) return;
       const normalized = normalizeTrackingPaste(paste);
-      const nextLink = normalized.tracking_link || String(formData.tracking_link ?? '');
       const nextNumber = normalized.tracking_number || String(formData.tracking_number ?? '');
-      if (normalized.tracking_link) setField('tracking_link', normalized.tracking_link);
+      let nextLink = normalized.tracking_link || String(formData.tracking_link ?? '');
+      // Number-only paste: fill a public track URL immediately (refined after live lookup).
+      if (!normalized.tracking_link && nextNumber && !String(formData.tracking_link ?? '').trim()) {
+        nextLink =
+          publicTrackingLink(nextNumber, String(formData.courier_name ?? '') || null) || nextLink;
+      }
+      if (nextLink) setField('tracking_link', nextLink);
       if (normalized.tracking_number) setField('tracking_number', normalized.tracking_number);
       const nextStatus = advanceShipmentStatusForTracking(
         formData.shipment_status,
@@ -478,6 +519,7 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
     const recordAny = record as Record<string, unknown>;
     setPriceFieldDraft({});
     setTrackingStatusDetail(null);
+    setTrackingDetails(null);
     const initial: Record<string, unknown> = {};
     formModalFields.forEach((f) => {
       const val = data[f.key] ?? recordAny[f.key];
@@ -767,7 +809,13 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
       dataToSend.shipment_status = advanceShipmentStatusForTracking(currentStatus, hasTracking);
 
       const prev = (record?.data && typeof record.data === 'object' ? record.data : {}) as Record<string, unknown>;
-      const keys = ['tracking_number', 'tracking_link', 'courier_name', 'shipment_status', 'eta'] as const;
+      const keys = [
+        'tracking_number',
+        'tracking_link',
+        'courier_name',
+        'shipment_status',
+        'eta',
+      ] as const;
       const changed = keys.some((k) => String(dataToSend[k] ?? '') !== String(prev[k] ?? ''));
       if (changed) {
         dataToSend.tracking_updated_at = new Date().toISOString();
@@ -1491,17 +1539,18 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
                   ) : null}
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  Paste a tracking link or AWB — we look up the carrier and move the delivery pipeline automatically.
+                  Paste a tracking link or AWB — we look up the carrier and update the delivery pipeline
+                  when scans are available. Pipeline is read-only.
                 </p>
                 <ShipmentDeliveryPipeline
                   status={formData.shipment_status}
                   disabled={!canUpdate || !!applyingStatusValue || trackingLiveLoading}
                   statusDetail={trackingStatusDetail}
+                  details={trackingDetails}
                   liveLoading={trackingLiveLoading}
                   onRefresh={() => {
                     void refreshLiveTracking();
                   }}
-                  onChange={(next) => setField('shipment_status', next)}
                 />
                 <div className="space-y-1.5">
                   <Label className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
@@ -1594,6 +1643,7 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
                       </SelectTrigger>
                       <SelectContent>
                         <SelectItem value="__auto__">Auto-detect</SelectItem>
+                        <SelectItem value="Amazon">Amazon</SelectItem>
                         <SelectItem value="BlueDart">BlueDart</SelectItem>
                         <SelectItem value="Delhivery">Delhivery</SelectItem>
                         <SelectItem value="FedEx">FedEx</SelectItem>

--- a/src/components/page-builder/ShipmentDeliveryPipeline.tsx
+++ b/src/components/page-builder/ShipmentDeliveryPipeline.tsx
@@ -1,37 +1,130 @@
 'use client';
 
-import React from 'react';
-import { Check, AlertTriangle } from 'lucide-react';
+import { Check, AlertTriangle, ArrowRight, MapPin } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
   SHIPMENT_PIPELINE_STEPS,
   normalizeShipmentStatus,
-  type ShipmentStatus,
+  type ShipmentTrackEvent,
+  type ShipmentTrackDetails,
 } from '@/lib/shipmentTracking';
 import { getShipmentStatusLabel } from '@/lib/inventoryStatusStyles';
 
 type ShipmentDeliveryPipelineProps = {
   status: unknown;
   disabled?: boolean;
-  /** Optional manual override; live tracking is the primary source. */
-  onChange?: (status: ShipmentStatus) => void;
   statusDetail?: string | null;
   liveLoading?: boolean;
   onRefresh?: () => void;
+  /** Live carrier route + scan history from shipment-track. */
+  details?: ShipmentTrackDetails | null;
   className?: string;
 };
+
+function formatEventTime(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const raw = String(value).trim();
+  if (!raw) return null;
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return raw;
+  try {
+    return d.toLocaleString(undefined, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return raw;
+  }
+}
+
+function RouteRow({
+  origin,
+  destination,
+  currentLocation,
+}: {
+  origin?: string | null;
+  destination?: string | null;
+  currentLocation?: string | null;
+}) {
+  if (!origin && !destination && !currentLocation) return null;
+  return (
+    <div className="space-y-1.5 rounded-md border border-border/60 bg-background/70 px-2.5 py-2">
+      {(origin || destination) && (
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-foreground">
+          <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            From
+          </span>
+          <span className="font-medium">{origin || '—'}</span>
+          <ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+          <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            To
+          </span>
+          <span className="font-medium">{destination || '—'}</span>
+        </div>
+      )}
+      {currentLocation ? (
+        <p className="inline-flex items-start gap-1.5 text-xs text-muted-foreground">
+          <MapPin className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+          <span>
+            <span className="font-medium text-foreground">Last seen: </span>
+            {currentLocation}
+          </span>
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function EventsList({ events }: { events: ShipmentTrackEvent[] }) {
+  if (!events.length) return null;
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        Scan history
+      </p>
+      <ol className="max-h-52 space-y-0 overflow-y-auto rounded-md border border-border/60 bg-background/70">
+        {events.map((ev, index) => {
+          const when = formatEventTime(ev.time);
+          const key = `${ev.time ?? ''}-${ev.message ?? ''}-${ev.location ?? ''}-${index}`;
+          return (
+            <li
+              key={key}
+              className={cn(
+                'border-b border-border/50 px-2.5 py-2 last:border-b-0',
+                index === 0 && 'bg-sky-50/60'
+              )}
+            >
+              <div className="flex flex-wrap items-baseline justify-between gap-x-2 gap-y-0.5">
+                <p className="text-xs font-medium text-foreground">{ev.message || 'Update'}</p>
+                {when ? <p className="text-[10px] text-muted-foreground tabular-nums">{when}</p> : null}
+              </div>
+              {ev.location ? (
+                <p className="mt-0.5 text-[11px] text-muted-foreground">{ev.location}</p>
+              ) : null}
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}
 
 /**
  * Visual delivery pipeline for inventory_request.shipment_status.
  * Steps: Ordered → In transit → Out for delivery → Delivered.
+ * Read-only — status comes from live carrier tracking only.
+ * Also shows route (from → to) and carrier scan history when available.
  */
 export function ShipmentDeliveryPipeline({
   status,
   disabled = false,
-  onChange,
   statusDetail,
   liveLoading = false,
   onRefresh,
+  details,
   className,
 }: ShipmentDeliveryPipelineProps) {
   const normalized = normalizeShipmentStatus(status);
@@ -40,6 +133,9 @@ export function ShipmentDeliveryPipeline({
     normalized && !isException && normalized !== 'NOT_SHIPPED'
       ? SHIPMENT_PIPELINE_STEPS.indexOf(normalized as (typeof SHIPMENT_PIPELINE_STEPS)[number])
       : -1;
+
+  const events = Array.isArray(details?.events) ? details.events : [];
+  const hasRoute = Boolean(details?.origin || details?.destination || details?.current_location);
 
   return (
     <div className={cn('space-y-3 rounded-md border border-border/70 bg-muted/20 px-3 py-3', className)}>
@@ -71,7 +167,7 @@ export function ShipmentDeliveryPipeline({
       </div>
 
       {statusDetail ? (
-        <p className="text-xs text-muted-foreground line-clamp-2">{statusDetail}</p>
+        <p className="text-xs text-muted-foreground">{statusDetail}</p>
       ) : null}
 
       <div className="flex items-start w-full">
@@ -79,18 +175,13 @@ export function ShipmentDeliveryPipeline({
           const done = activeIndex > index;
           const current = activeIndex === index;
           const upcoming = activeIndex < index;
-          const clickable = Boolean(onChange) && !disabled;
 
+          // Use a real element (not Fragment): Vite/lovable injects data-lov-id
+          // onto JSX nodes, and React.Fragment only allows `key` + `children`.
           return (
-            <React.Fragment key={step}>
-              <button
-                type="button"
-                disabled={!clickable}
-                onClick={() => onChange?.(step)}
-                className={cn(
-                  'flex flex-col items-center gap-1.5 min-w-0 flex-1 text-center',
-                  clickable ? 'cursor-pointer group' : 'cursor-default'
-                )}
+            <span key={step} className="contents">
+              <div
+                className="flex flex-col items-center gap-1.5 min-w-0 flex-1 text-center cursor-default"
                 title={getShipmentStatusLabel(step)}
               >
                 <span
@@ -99,8 +190,7 @@ export function ShipmentDeliveryPipeline({
                     done && 'border-emerald-500 bg-emerald-500 text-white',
                     current && 'border-sky-500 bg-sky-500 text-white ring-2 ring-sky-200',
                     upcoming && !isException && 'border-border bg-background text-muted-foreground',
-                    isException && 'border-rose-300 bg-rose-50 text-rose-700',
-                    clickable && upcoming && 'group-hover:border-sky-300 group-hover:text-sky-700'
+                    isException && 'border-rose-300 bg-rose-50 text-rose-700'
                   )}
                 >
                   {done ? <Check className="h-3.5 w-3.5" aria-hidden /> : index + 1}
@@ -115,7 +205,7 @@ export function ShipmentDeliveryPipeline({
                 >
                   {getShipmentStatusLabel(step)}
                 </span>
-              </button>
+              </div>
               {index < SHIPMENT_PIPELINE_STEPS.length - 1 ? (
                 <div
                   className={cn(
@@ -125,45 +215,27 @@ export function ShipmentDeliveryPipeline({
                   aria-hidden
                 />
               ) : null}
-            </React.Fragment>
+            </span>
           );
         })}
       </div>
 
-      {onChange && !disabled ? (
-        <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            className={cn(
-              'inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[11px]',
-              normalized === 'NOT_SHIPPED' || !normalized
-                ? 'border-slate-300 bg-slate-50 text-slate-800'
-                : 'border-border bg-background text-muted-foreground hover:bg-muted/50'
-            )}
-            onClick={() => onChange('NOT_SHIPPED')}
-          >
-            Not shipped
-          </button>
-          <button
-            type="button"
-            className={cn(
-              'inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[11px]',
-              isException
-                ? 'border-rose-300 bg-rose-50 text-rose-800'
-                : 'border-border bg-background text-muted-foreground hover:bg-muted/50'
-            )}
-            onClick={() => onChange('EXCEPTION')}
-          >
-            <AlertTriangle className="h-3 w-3" aria-hidden />
-            Exception
-          </button>
-        </div>
-      ) : isException ? (
+      {isException ? (
         <p className="inline-flex items-center gap-1.5 text-xs text-rose-700">
           <AlertTriangle className="h-3.5 w-3.5" aria-hidden />
           Shipment exception — check with courier / vendor.
         </p>
       ) : null}
+
+      {hasRoute ? (
+        <RouteRow
+          origin={details?.origin}
+          destination={details?.destination}
+          currentLocation={details?.current_location}
+        />
+      ) : null}
+
+      <EventsList events={events} />
     </div>
   );
 }

--- a/src/lib/shipmentTracking.ts
+++ b/src/lib/shipmentTracking.ts
@@ -45,6 +45,20 @@ export function advanceShipmentStatusForTracking(
   return normalized;
 }
 
+export type ShipmentTrackEvent = {
+  time?: string | null;
+  message?: string | null;
+  location?: string | null;
+  status?: string | null;
+};
+
+export type ShipmentTrackDetails = {
+  origin?: string | null;
+  destination?: string | null;
+  current_location?: string | null;
+  events?: ShipmentTrackEvent[];
+};
+
 export type LiveShipmentTrackResult = {
   ok?: boolean;
   shipment_status?: string | null;
@@ -56,7 +70,88 @@ export type LiveShipmentTrackResult = {
   error?: string | null;
   method?: string | null;
   tracked_at?: string | null;
+  origin?: string | null;
+  destination?: string | null;
+  current_location?: string | null;
+  events?: ShipmentTrackEvent[];
 };
+
+export function shipmentDetailsFromTrackResult(
+  result: LiveShipmentTrackResult | null | undefined
+): ShipmentTrackDetails | null {
+  if (!result) return null;
+  const events = Array.isArray(result.events) ? result.events : [];
+  const details: ShipmentTrackDetails = {
+    origin: result.origin ?? null,
+    destination: result.destination ?? null,
+    current_location: result.current_location ?? null,
+    events,
+  };
+  if (!details.origin && !details.destination && !details.current_location && events.length === 0) {
+    return null;
+  }
+  return details;
+}
+
+export function looksLikeAmazonTrackingId(value: string | null | undefined): boolean {
+  const v = String(value ?? '').trim();
+  if (!v) return false;
+  if (/^\d{3}-\d{7}-\d{7}$/.test(v)) return true;
+  if (/^TBA[0-9A-Z]{8,}$/i.test(v)) return true;
+  if (/^(TBA|AMZL)/i.test(v)) return true;
+  return false;
+}
+
+/** Map AfterShip slugs / labels onto our Courier select values. */
+export function normalizeCourierLabel(value: string | null | undefined): string | null {
+  const raw = String(value ?? '').trim();
+  if (!raw) return null;
+  const key = raw.toLowerCase().replace(/[\s_]+/g, '-');
+  if (key.startsWith('amazon')) return 'Amazon';
+  if (key.startsWith('fedex')) return 'FedEx';
+  if (key === 'dhl' || key.startsWith('dhl-')) return 'DHL';
+  if (key.includes('bluedart') || key.includes('blue-dart')) return 'BlueDart';
+  if (key.includes('delhivery')) return 'Delhivery';
+  if (key.includes('dtdc')) return 'DTDC';
+  if (key.includes('shiprocket')) return 'Shiprocket';
+  if (key.includes('india-post') || key.includes('indiapost')) return 'India Post';
+  return raw;
+}
+
+export function publicTrackingLink(
+  awb: string | null | undefined,
+  courier?: string | null
+): string | null {
+  const number = String(awb ?? '').trim();
+  if (!number) return null;
+  const safe = encodeURIComponent(number);
+  const raw = String(courier ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, '-');
+  let slug = raw;
+  if (raw.includes('fedex')) slug = 'fedex';
+  else if (raw === 'dhl' || raw.startsWith('dhl')) slug = 'dhl';
+  else if (raw.includes('bluedart') || raw.includes('blue-dart')) slug = 'bluedart';
+  else if (raw.includes('delhivery')) slug = 'delhivery';
+  else if (raw.includes('dtdc')) slug = 'dtdc';
+  else if (raw.includes('shiprocket')) slug = 'shiprocket';
+  else if (raw.includes('india-post') || raw.includes('indiapost') || raw === 'india post')
+    slug = 'india-post';
+
+  if (slug === 'fedex') return `https://www.fedex.com/fedextrack/?trknbr=${safe}`;
+  if (slug === 'dhl' || slug.startsWith('dhl'))
+    return `https://www.dhl.com/en/express/tracking.html?AWB=${safe}&brand=DHL`;
+  if (slug === 'delhivery') return `https://www.delhivery.com/track/package/?waybill=${safe}`;
+  if (slug === 'bluedart') return `https://www.aftership.com/track/bluedart/${safe}`;
+  if (slug === 'dtdc') return `https://www.aftership.com/track/dtdc/${safe}`;
+  if (slug === 'shiprocket') return `https://www.aftership.com/track/shiprocket/${safe}`;
+  if (slug === 'india-post') return `https://www.aftership.com/track/india-post/${safe}`;
+  if (slug && !['aftership', 'auto-detect', 'auto', '__auto__'].includes(slug)) {
+    return `https://www.aftership.com/track/${encodeURIComponent(slug)}/${safe}`;
+  }
+  return `https://www.aftership.com/track/${safe}`;
+}
 
 /**
  * Ask the backend to resolve live carrier status from AWB / tracking link.
@@ -67,13 +162,40 @@ export async function fetchLiveShipmentStatus(input: {
   tracking_link?: string | null;
   courier_name?: string | null;
 }): Promise<LiveShipmentTrackResult> {
-  const { apiClient } = await import('@/lib/api');
-  const res = await apiClient.post<LiveShipmentTrackResult>('/crm-records/shipment-track/', {
+  const body = {
     tracking_number: input.tracking_number || null,
     tracking_link: input.tracking_link || null,
     courier_name: input.courier_name || null,
-  });
-  return res.data ?? {};
+  };
+  console.log('[shipment-track] request', body);
+  try {
+    const { apiClient } = await import('@/lib/api');
+    const res = await apiClient.post<LiveShipmentTrackResult>('/crm-records/shipment-track/', body, {
+      timeout: 30000,
+    });
+    const data = res.data ?? {};
+    console.log('[shipment-track] response', {
+      ok: data.ok,
+      shipment_status: data.shipment_status,
+      status_detail: data.status_detail,
+      courier_name: data.courier_name,
+      method: data.method,
+      error: data.error,
+      tracking_number: data.tracking_number,
+      tracking_link: data.tracking_link,
+      eta: data.eta,
+      tracked_at: data.tracked_at,
+      origin: data.origin,
+      destination: data.destination,
+      current_location: data.current_location,
+      events_count: Array.isArray(data.events) ? data.events.length : 0,
+      full: data,
+    });
+    return data;
+  } catch (err) {
+    console.error('[shipment-track] request failed', err);
+    throw err;
+  }
 }
 
 /** Request statuses where the shipment tracking editor is shown. */
@@ -166,16 +288,6 @@ export function extractTrackingNumberFromUrl(url: string): string | null {
       if (last && /^[A-Za-z0-9-]{6,}$/.test(last) && !/^(track|tracking|shipment|order)$/i.test(last)) {
         return last;
       }
-    }
-
-    // Amazon progress tracker: packageId / trackingId in query
-    if (host.includes('amazon.')) {
-      const amazonId =
-        params.get('packageId') ||
-        params.get('trackingId') ||
-        params.get('orderId') ||
-        params.get('shipmentId');
-      if (amazonId && String(amazonId).trim()) return String(amazonId).trim();
     }
   } catch {
     // ignore parse errors


### PR DESCRIPTION
Rely on AfterShip for multi-carrier status, synthesize tracking links when only an AWB is pasted, and keep Amazon ids from being mislabeled as FedEx.