### PR TITLE
Show date-based Priority instead of Urgency in request modals.

### DIFF
--- a/src/components/page-builder/InventoryFormEditModal.tsx
+++ b/src/components/page-builder/InventoryFormEditModal.tsx
@@ -22,12 +22,12 @@ import { Loader2, Trash2 } from 'lucide-react';
 import { Checkbox } from '@/components/ui/checkbox';
 import { formatCurrencyDisplay, formatCurrencyInputLive, parseCurrencyInput } from '@/lib/currencyFormat';
 import { cn } from '@/lib/utils';
+import { urgencyToneButtonClassName } from '@/lib/urgencyButtonStyles';
 import {
-  urgencyToneButtonClassName,
-  urgencyReadonlyFieldCardClassName,
-  urgencyReadonlyValueTextClassName,
-  isUrgencyToneValue,
-} from '@/lib/urgencyButtonStyles';
+  resolvePriorityFromRow,
+  inventoryPriorityFieldCardClassName,
+  inventoryPriorityValueTextClassName,
+} from '@/lib/inventoryPriority';
 import { getInventoryStatusLabel, getInventoryStatusToneClass } from '@/lib/inventoryStatusStyles';
 import { OpenLinkButton } from '@/components/page-builder/OpenLinkButton';
 import { RecordModalTitleDisplay } from '@/components/page-builder/RecordModalTitleDisplay';
@@ -188,10 +188,6 @@ function toCurrencyNumber(value: unknown): number | null {
 
 /** Keys that we render as textarea (multi-line). */
 const TEXTAREA_KEYS = new Set(['comments', 'notes', 'description', 'item_name_freeform', 'project_purpose']);
-const URGENCY_BUTTON_OPTIONS: Array<{ value: string; label: string }> = [
-  { value: 'STANDARD', label: 'Standard' },
-  { value: 'CRITICAL', label: 'Critical' },
-];
 
 /** Keys that are typically numbers. */
 const NUMBER_KEYS = new Set([
@@ -1226,10 +1222,17 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
               const isStatus = field.key === 'status' && statusOptions.length > 0;
               const isVendor = field.key === 'vendor';
               const isBoolean = typeof value === 'boolean';
-              const isUrgency = field.key === 'urgency_level';
+              // urgency_level slot now shows date-derived Priority (not CRITICAL/STANDARD).
+              const isPriorityField = field.key === 'urgency_level' || field.key === 'priority';
+              const priorityDisplay = isPriorityField
+                ? resolvePriorityFromRow(record, formData.urgency_level ?? formData.priority ?? value)
+                : '';
               const isTextarea = TEXTAREA_KEYS.has(field.key);
               const isNumber = NUMBER_KEYS.has(field.key);
               const spanFullWidth = TEXTAREA_KEYS.has(field.key);
+              const fieldLabel = isPriorityField
+                ? 'Priority'
+                : field.label || field.key.replace(/_/g, ' ');
 
               return (
                 <div
@@ -1238,7 +1241,7 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
                 >
                   <div className="flex flex-wrap items-center justify-between gap-2 min-w-0">
                     <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      {field.label || field.key.replace(/_/g, ' ')}
+                      {fieldLabel}
                     </Label>
                     {isClickableLink ? <OpenLinkButton href={displayStr} /> : null}
                   </div>
@@ -1377,47 +1380,25 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
                         <SelectItem value="false">No</SelectItem>
                       </SelectContent>
                     </Select>
-                  ) : isUrgency ? (
-                    !isEnabled ? (
-                      <div
+                  ) : isPriorityField ? (
+                    <div
+                      className={cn(
+                        'rounded-lg border px-3 py-2.5 shadow-sm',
+                        inventoryPriorityFieldCardClassName(priorityDisplay),
+                      )}
+                      role="status"
+                      aria-label="Priority"
+                      title="Derived from Request Date vs Requirement Date"
+                    >
+                      <span
                         className={cn(
-                          'rounded-lg border px-3 py-2.5 shadow-sm',
-                          isUrgencyToneValue(displayStr)
-                            ? urgencyReadonlyFieldCardClassName(String(displayStr))
-                            : 'border-border bg-card',
+                          'text-base font-bold tracking-wide',
+                          inventoryPriorityValueTextClassName(priorityDisplay),
                         )}
-                        role="status"
-                        aria-label="Urgency"
                       >
-                        <span
-                          className={cn(
-                            'text-base font-bold tracking-wide uppercase',
-                            urgencyReadonlyValueTextClassName(String(displayStr)),
-                          )}
-                        >
-                          {displayStr && displayStr !== 'N/A' ? String(displayStr).trim() : '—'}
-                        </span>
-                      </div>
-                    ) : (
-                      <div className="flex flex-wrap gap-2" role="group" aria-label="Urgency level">
-                        {URGENCY_BUTTON_OPTIONS.map((opt) => {
-                          const selected = String(displayStr || '').toUpperCase() === opt.value;
-                          return (
-                            <Button
-                              key={opt.value}
-                              type="button"
-                              variant="outline"
-                              size="sm"
-                              onClick={() => setField(field.key, opt.value)}
-                              disabled={!isEnabled}
-                              className={urgencyToneButtonClassName(opt.value, selected, 'rounded-full h-8')}
-                            >
-                              {opt.label}
-                            </Button>
-                          );
-                        })}
-                      </div>
-                    )
+                        {priorityDisplay}
+                      </span>
+                    </div>
                   ) : isTextarea ? (
                     <Textarea
                       className="min-h-[80px] text-sm rounded-md"

--- a/src/components/page-builder/LeadTableComponent.tsx
+++ b/src/components/page-builder/LeadTableComponent.tsx
@@ -437,7 +437,7 @@ const DEFAULT_INVENTORY_REQUEST_FORM_MODAL_FIELDS: Array<{ key: string; label: s
   { key: 'additional_link', label: 'Additional link', enabled: false, link: true },
   { key: 'comments', label: 'Comments', enabled: true },
   { key: 'notes', label: 'Notes', enabled: true },
-  { key: 'urgency_level', label: 'Urgency', enabled: true },
+  { key: 'urgency_level', label: 'Priority', enabled: false },
   { key: 'project_purpose', label: 'Project / purpose', enabled: true },
   { key: 'department', label: 'Department', enabled: true },
 ];
@@ -2531,13 +2531,18 @@ export const LeadTableComponent: React.FC<LeadTableProps> = ({ config, pageId })
           record={selectedRecord}
           entityType={config?.entityType}
           formModalFields={
-            (config?.formModalFields?.length
+            ((config?.formModalFields?.length
               ? config.formModalFields
               : effectiveDetailMode === 'inventory_payment_modal'
                 ? DEFAULT_PAYMENT_MODAL_FIELDS
-                : config?.entityType === 'inventory_request'
+                : config?.entityType === 'inventory_request' || config?.entityType === 'unmannd_request'
                   ? DEFAULT_INVENTORY_REQUEST_FORM_MODAL_FIELDS
                   : []) ?? []
+            ).map((field) =>
+              field.key === 'urgency_level' || field.key === 'priority'
+                ? { ...field, label: 'Priority', enabled: false }
+                : field
+            )
           }
           formModalTitle={config?.formModalTitle}
           formModalDescription={config?.formModalDescription}

--- a/src/components/page-builder/RecordDetailModal.tsx
+++ b/src/components/page-builder/RecordDetailModal.tsx
@@ -36,11 +36,11 @@ import {
 import { cn } from '@/lib/utils';
 import { getInventoryStatusLabel, getInventoryStatusToneClass } from '@/lib/inventoryStatusStyles';
 import {
-  urgencyToneButtonClassName,
-  urgencyReadonlyFieldCardClassName,
-  urgencyReadonlyValueTextClassName,
-  isUrgencyToneValue,
-} from '@/lib/urgencyButtonStyles';
+  resolvePriorityFromRow,
+  inventoryPriorityFieldCardClassName,
+  inventoryPriorityValueTextClassName,
+} from '@/lib/inventoryPriority';
+import { urgencyToneButtonClassName } from '@/lib/urgencyButtonStyles';
 import { OpenLinkButton } from '@/components/page-builder/OpenLinkButton';
 import { RecordModalTitleDisplay } from '@/components/page-builder/RecordModalTitleDisplay';
 import { StatusActionWarningModal, type StatusActionWithWarningConfig } from '@/components/config_components/StatusActionWarningModal';
@@ -108,7 +108,8 @@ const EDITABLE_FIELDS_FOR_REQUESTER: string[] = [
   // 'part_number_or_sku',
   'quantity_required',
   'comments',
-  'urgency_level',
+  // Priority is derived from request/requirement dates — not editable as urgency.
+  // 'urgency_level',
   // 'expected_delivery_date',
   // 'procurement_type',
   'quantity',
@@ -188,11 +189,6 @@ const DETAIL_ROW_FULL_WIDTH_KEYS = new Set([
   'item_name_freeform',
   'project_purpose',
 ]);
-const URGENCY_BUTTON_OPTIONS: Array<{ value: string; label: string }> = [
-  { value: 'STANDARD', label: 'Standard' },
-  { value: 'CRITICAL', label: 'Critical' },
-];
-
 /**
  * Build display rows from API-shaped record only:
  * - Standard top-level: id, entity_type, created_at, updated_at, pyro_data (no tenant_id)
@@ -462,7 +458,8 @@ function humanizeLabel(key: string): string {
     item_name_freeform: 'Item name',
     product_link: 'Product link',
     part_number_or_sku: 'Part number / SKU',
-    urgency_level: 'Urgency',
+    urgency_level: 'Priority',
+    priority: 'Priority',
     expected_delivery_date: 'Expected delivery',
     procurement_type: 'Procurement type',
     invoice_number: 'Invoice number',
@@ -1181,25 +1178,29 @@ export const RecordDetailModal: React.FC<RecordDetailModalProps> = ({
                                   placeholder="Add a new comment..."
                                 />
                               </div>
-                            ) : key === 'urgency_level' ? (
-                              <div className="flex flex-wrap gap-2" role="group" aria-label="Urgency level">
-                                {URGENCY_BUTTON_OPTIONS.map((opt) => {
-                                  const selected = String(displayValue ?? '').toUpperCase() === opt.value;
-                                  return (
-                                    <Button
-                                      key={opt.value}
-                                      type="button"
-                                      variant="outline"
-                                      size="sm"
-                                      onClick={() => handleEditableChange(key, value, opt.value)}
-                                      disabled={isSaving}
-                                      className={urgencyToneButtonClassName(opt.value, selected, 'rounded-full h-8')}
+                            ) : key === 'urgency_level' || key === 'priority' ? (
+                              (() => {
+                                const priorityDisplay = resolvePriorityFromRow(record, displayValue);
+                                return (
+                                  <div
+                                    className={cn(
+                                      'inline-flex max-w-full rounded-lg border px-3 py-2.5 shadow-sm',
+                                      inventoryPriorityFieldCardClassName(priorityDisplay),
+                                    )}
+                                    role="status"
+                                    title="Derived from Request Date vs Requirement Date"
+                                  >
+                                    <span
+                                      className={cn(
+                                        'text-base font-bold tracking-wide break-words',
+                                        inventoryPriorityValueTextClassName(priorityDisplay),
+                                      )}
                                     >
-                                      {opt.label}
-                                    </Button>
-                                  );
-                                })}
-                              </div>
+                                      {priorityDisplay}
+                                    </span>
+                                  </div>
+                                );
+                              })()
                             ) : (
                               <Input
                                 className="w-full max-w-md min-w-0 h-9 text-sm rounded-md"
@@ -1209,6 +1210,7 @@ export const RecordDetailModal: React.FC<RecordDetailModalProps> = ({
                               />
                             )
                           }
+                          {key !== 'urgency_level' && key !== 'priority' ? (
                           <Button
                             type="button"
                             variant="secondary"
@@ -1224,26 +1226,34 @@ export const RecordDetailModal: React.FC<RecordDetailModalProps> = ({
                               <Save className="h-3.5 w-3.5" aria-hidden />
                             )}
                           </Button>
+                          ) : null}
                         </div>
-                      ) : key === 'urgency_level' && String(displayValue ?? '').trim() && displayValue !== '—' ? (
-                        <div
-                          className={cn(
-                            'inline-flex max-w-full rounded-lg border px-3 py-2.5 shadow-sm',
-                            isUrgencyToneValue(String(displayValue))
-                              ? urgencyReadonlyFieldCardClassName(String(displayValue))
-                              : 'border-border bg-card',
-                          )}
-                          role="status"
-                        >
-                          <span
-                            className={cn(
-                              'text-base font-bold tracking-wide uppercase break-words',
-                              urgencyReadonlyValueTextClassName(String(displayValue)),
-                            )}
-                          >
-                            {String(displayValue).trim()}
-                          </span>
-                        </div>
+                      ) : (key === 'urgency_level' || key === 'priority') ? (
+                        (() => {
+                          const priorityDisplay = resolvePriorityFromRow(record, displayValue);
+                          if (!priorityDisplay || priorityDisplay === '—') {
+                            return <span className="text-muted-foreground">—</span>;
+                          }
+                          return (
+                            <div
+                              className={cn(
+                                'inline-flex max-w-full rounded-lg border px-3 py-2.5 shadow-sm',
+                                inventoryPriorityFieldCardClassName(priorityDisplay),
+                              )}
+                              role="status"
+                              title="Derived from Request Date vs Requirement Date"
+                            >
+                              <span
+                                className={cn(
+                                  'text-base font-bold tracking-wide break-words',
+                                  inventoryPriorityValueTextClassName(priorityDisplay),
+                                )}
+                              >
+                                {priorityDisplay}
+                              </span>
+                            </div>
+                          );
+                        })()
                       ) : key === 'status' && String(displayValue ?? '').trim() ? (
                         <span
                           className={cn(

--- a/src/lib/inventoryPriority.ts
+++ b/src/lib/inventoryPriority.ts
@@ -80,3 +80,39 @@ export function formatInventoryPriorityLabel(value: unknown): string {
   }
   return raw;
 }
+
+/** Normalize a priority label/value to HIGH | MEDIUM | LOW when possible. */
+export function normalizeInventoryPriorityLevel(value: unknown): 'HIGH' | 'MEDIUM' | 'LOW' | null {
+  const raw = String(value ?? '').trim();
+  if (!raw || raw === '—') return null;
+  const upper = raw.toUpperCase();
+  const lower = raw.toLowerCase();
+  if (upper === 'HIGH' || lower.startsWith('high') || upper === 'CRITICAL') return 'HIGH';
+  if (upper === 'MEDIUM' || lower.startsWith('medium') || lower.startsWith('middle')) return 'MEDIUM';
+  if (upper === 'LOW' || lower.startsWith('low') || upper === 'STANDARD') return 'LOW';
+  return null;
+}
+
+/** Card background/border for read-only Priority in request modals. */
+export function inventoryPriorityFieldCardClassName(value: unknown): string {
+  const level = normalizeInventoryPriorityLevel(value);
+  if (level === 'HIGH') {
+    return 'border-orange-200 bg-orange-50/80 dark:border-orange-800/80 dark:bg-orange-950/35';
+  }
+  if (level === 'MEDIUM') {
+    return 'border-amber-200 bg-amber-50/80 dark:border-amber-800/80 dark:bg-amber-950/35';
+  }
+  if (level === 'LOW') {
+    return 'border-sky-200 bg-sky-50/80 dark:border-sky-800/80 dark:bg-sky-950/35';
+  }
+  return 'border-border bg-card';
+}
+
+/** Text color for read-only Priority value. */
+export function inventoryPriorityValueTextClassName(value: unknown): string {
+  const level = normalizeInventoryPriorityLevel(value);
+  if (level === 'HIGH') return 'text-orange-950 dark:text-orange-50';
+  if (level === 'MEDIUM') return 'text-amber-950 dark:text-amber-50';
+  if (level === 'LOW') return 'text-sky-950 dark:text-sky-50';
+  return 'text-foreground';
+}


### PR DESCRIPTION
Replace Critical/Standard urgency controls with read-only Priority derived from request and requirement dates for manager and team-lead request views.