### PR TITLE
Polish procurement modal header and show price, cost, and requested date

### DIFF
--- a/src/components/page-builder/InventoryFormEditModal.tsx
+++ b/src/components/page-builder/InventoryFormEditModal.tsx
@@ -21,6 +21,7 @@ import { ALLOWED_STATUSES } from '@/constants/inventory';
 import { Loader2, Trash2 } from 'lucide-react';
 import { Checkbox } from '@/components/ui/checkbox';
 import { formatCurrencyDisplay, formatCurrencyInputLive, parseCurrencyInput } from '@/lib/currencyFormat';
+import { formatCalendarDate } from '@/lib/timeUtils';
 import { cn } from '@/lib/utils';
 import { urgencyToneButtonClassName } from '@/lib/urgencyButtonStyles';
 import {
@@ -1217,8 +1218,9 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
               const displayStr = PRICE_KEYS.has(field.key) ? formatPriceFieldDisplay(value) : formatDisplayValue(value);
               const normalizedVendorValue = field.key === 'vendor' ? toVendorStorageName(displayStr) : '';
               const isEnabled = field.enabled && canUpdate;
-              const isClickableLink =
-                !isEnabled && looksLikeUrl(displayStr) && (field.link === true || isLinkLikeFieldKey(field.key));
+              const isLinkField = field.link === true || isLinkLikeFieldKey(field.key);
+              const hasUrl = looksLikeUrl(displayStr);
+              const isClickableProductLink = isLinkField && hasUrl;
               const isStatus = field.key === 'status' && statusOptions.length > 0;
               const isVendor = field.key === 'vendor';
               const isBoolean = typeof value === 'boolean';
@@ -1227,12 +1229,44 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
               const priorityDisplay = isPriorityField
                 ? resolvePriorityFromRow(record, formData.urgency_level ?? formData.priority ?? value)
                 : '';
+              const isLineTotal = field.key === 'line_total' || field.key === 'computed_price';
+              const isRequestDateField = field.key === 'request_date' || field.key === 'requested_date';
+              const lineTotalDisplay = (() => {
+                if (!isLineTotal) return '';
+                const qtyRaw =
+                  formData.quantity ??
+                  formData.quantity_required ??
+                  (record?.data as any)?.quantity ??
+                  (record?.data as any)?.quantity_required;
+                const costRaw =
+                  formData.estimated_cost ?? (record?.data as any)?.estimated_cost;
+                const qty = Number(qtyRaw);
+                const cost = typeof costRaw === 'number' ? costRaw : Number(String(costRaw ?? '').replace(/,/g, ''));
+                if (!Number.isFinite(qty) || !Number.isFinite(cost)) return '—';
+                return formatCurrencyDisplay(Math.round(qty * cost * 100) / 100);
+              })();
+              const requestDateDisplay = isRequestDateField
+                ? formatCalendarDate(
+                    String(
+                      formData.request_date ??
+                        formData.requested_date ??
+                        (record?.data as any)?.request_date ??
+                        (record?.data as any)?.requested_date ??
+                        displayStr ??
+                        ''
+                    )
+                  )
+                : '';
               const isTextarea = TEXTAREA_KEYS.has(field.key);
               const isNumber = NUMBER_KEYS.has(field.key);
               const spanFullWidth = TEXTAREA_KEYS.has(field.key);
               const fieldLabel = isPriorityField
                 ? 'Priority'
-                : field.label || field.key.replace(/_/g, ' ');
+                : isLineTotal
+                  ? 'Price'
+                  : isRequestDateField
+                    ? 'Requested Date'
+                    : field.label || field.key.replace(/_/g, ' ');
 
               return (
                 <div
@@ -1243,10 +1277,23 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
                     <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
                       {fieldLabel}
                     </Label>
-                    {isClickableLink ? <OpenLinkButton href={displayStr} /> : null}
                   </div>
-                  {!isClickableLink ? (
-                    field.key === 'comments' ? (
+                  {isLineTotal ? (
+                    <div
+                      className="flex h-9 w-full items-center rounded-md border border-border/60 bg-muted/20 px-3 text-sm font-mono tabular-nums font-semibold text-foreground"
+                      role="status"
+                      title="Quantity × Estimated cost"
+                    >
+                      {lineTotalDisplay}
+                    </div>
+                  ) : isRequestDateField ? (
+                    <div
+                      className="flex h-9 w-full items-center rounded-md border border-border/60 bg-muted/20 px-3 text-sm text-foreground"
+                      role="status"
+                    >
+                      {requestDateDisplay || '—'}
+                    </div>
+                  ) : field.key === 'comments' ? (
                     (() => {
                       const existingRaw = (record?.data && typeof record.data === 'object' ? (record.data as any).comments : undefined) as unknown;
                       const history: Array<{ name: string; role: string; comment: string }> = Array.isArray(existingRaw)
@@ -1464,6 +1511,16 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
                         disabled={!isEnabled}
                       />
                     )
+                  ) : isClickableProductLink ? (
+                    <a
+                      href={displayStr}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title={displayStr}
+                      className="flex h-9 w-full items-center rounded-md border border-input bg-background px-3 text-sm text-black break-all truncate transition-colors hover:text-black active:border-black active:bg-black active:text-white"
+                    >
+                      {displayStr}
+                    </a>
                   ) : (
                     <Input
                       className="h-9 text-sm rounded-md"
@@ -1472,8 +1529,7 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
                       disabled={!isEnabled}
                       placeholder={field.label || field.key}
                     />
-                  ))
-                  : null}
+                  )}
                 </div>
               );
             })}

--- a/src/components/page-builder/ProcurementTableComponent.tsx
+++ b/src/components/page-builder/ProcurementTableComponent.tsx
@@ -63,8 +63,11 @@ export const DEFAULT_PROCUREMENT_TABLE_CONFIG = {
     { key: 'status', label: 'Status', enabled: false },
     { key: 'item_name_freeform', label: 'Item', enabled: false },
     { key: 'quantity_required', label: 'Quantity', enabled: true },
+    { key: 'estimated_cost', label: 'Estimated Cost', enabled: false },
+    { key: 'line_total', label: 'Price', enabled: false },
+    { key: 'request_date', label: 'Requested Date', enabled: false },
     { key: 'vendor', label: 'Vendor', enabled: true },
-    { key: 'urgency_level', label: 'Urgency', enabled: true },
+    { key: 'urgency_level', label: 'Priority', enabled: false },
     { key: 'department', label: 'Department', enabled: false },
     { key: 'specifications', label: 'Specifications', enabled: true },
     { key: 'product_link', label: 'Product link', enabled: true, link: true },
@@ -99,6 +102,44 @@ function entityTypeFromEndpoint(apiEndpoint?: string): string | undefined {
     const match = /[?&]entity_type=([^&]*)/.exec(normalized);
     return match?.[1] ? decodeURIComponent(match[1]).trim() : undefined;
   }
+}
+
+/** Ensure Price (qty × estimated cost) and Requested Date always appear in the procurement modal. */
+function withProcurementModalFields(
+  fields: Array<{ key: string; label: string; enabled: boolean; link?: boolean }>
+): Array<{ key: string; label: string; enabled: boolean; link?: boolean }> {
+  const keys = new Set(fields.map((f) => f.key));
+  const next = [...fields];
+
+  const insertAfter = (afterKey: string, field: { key: string; label: string; enabled: boolean; link?: boolean }) => {
+    if (keys.has(field.key)) return;
+    const idx = next.findIndex((f) => f.key === afterKey);
+    if (idx >= 0) next.splice(idx + 1, 0, field);
+    else next.push(field);
+    keys.add(field.key);
+  };
+
+  insertAfter('quantity_required', { key: 'estimated_cost', label: 'Estimated Cost', enabled: false });
+  if (!keys.has('estimated_cost')) {
+    insertAfter('quantity', { key: 'estimated_cost', label: 'Estimated Cost', enabled: false });
+  }
+  insertAfter('estimated_cost', { key: 'line_total', label: 'Price', enabled: false });
+  if (!keys.has('line_total')) {
+    insertAfter('quantity_required', { key: 'line_total', label: 'Price', enabled: false });
+  }
+  if (!keys.has('line_total')) {
+    insertAfter('quantity', { key: 'line_total', label: 'Price', enabled: false });
+  }
+  insertAfter('line_total', { key: 'request_date', label: 'Requested Date', enabled: false });
+  if (!keys.has('request_date')) {
+    next.push({ key: 'request_date', label: 'Requested Date', enabled: false });
+  }
+
+  return next.map((f) =>
+    f.key === 'urgency_level' || f.key === 'priority'
+      ? { ...f, label: 'Priority', enabled: false }
+      : f
+  );
 }
 
 /**
@@ -154,10 +195,11 @@ export const ProcurementTableComponent: React.FC<ProcurementTableProps> = ({ con
       tableType,
       detailMode,
       // Ensure Manager All Requests always has form fields for the Approve/Reject modal.
-      formModalFields:
+      formModalFields: withProcurementModalFields(
         Array.isArray(config?.formModalFields) && config.formModalFields.length > 0
           ? config.formModalFields
-          : DEFAULT_PROCUREMENT_TABLE_CONFIG.formModalFields,
+          : DEFAULT_PROCUREMENT_TABLE_CONFIG.formModalFields
+      ),
       showFinalPriceSection: config?.showFinalPriceSection ?? false,
       // If someone still uses inventory_request mode, force form_edit.
       ...(detailMode === 'inventory_request'

--- a/src/components/page-builder/RecordModalTitleDisplay.tsx
+++ b/src/components/page-builder/RecordModalTitleDisplay.tsx
@@ -7,7 +7,7 @@ type RecordModalTitleDisplayProps = {
 };
 
 /**
- * Readable modal header: request # (chip), item name (emphasis), date (muted).
+ * Readable modal header: Request Number | Item · Date (24 July 2026).
  */
 export function RecordModalTitleDisplay({ record }: RecordModalTitleDisplayProps) {
   const parts = getRecordModalTitleParts(record);
@@ -17,30 +17,36 @@ export function RecordModalTitleDisplay({ record }: RecordModalTitleDisplayProps
   }
 
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-baseline sm:gap-x-4 sm:gap-y-2">
-      <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-3 gap-y-2">
-        <span
-          className="inline-flex w-fit shrink-0 items-center rounded-md border border-border/80 bg-muted/50 px-2.5 py-1 text-sm font-semibold tabular-nums tracking-tight text-muted-foreground shadow-sm"
-          title="Request number"
-        >
-          #{parts.idNum}
-        </span>
-        <span
-          className="min-w-0 max-w-full text-lg font-semibold leading-snug tracking-tight text-foreground sm:text-xl"
-          title={parts.itemName === '—' ? undefined : parts.itemName}
-        >
-          <span className="line-clamp-3 break-words">{parts.itemName}</span>
-        </span>
-      </div>
-      <div className="flex shrink-0 items-center gap-3 border-t border-border/60 pt-2 sm:border-t-0 sm:border-l sm:pl-4 sm:pt-0">
-        <time
-          className="text-sm font-medium tabular-nums text-muted-foreground sm:text-base"
-          dateTime={parts.dateTimeAttr}
-          title="Date"
-        >
-          {parts.dateDisplay}
-        </time>
-      </div>
+    <div className="flex min-w-0 flex-wrap items-center gap-x-2.5 gap-y-1.5">
+      <span
+        className="inline-flex shrink-0 items-center rounded-md bg-muted px-2 py-0.5 font-mono text-[13px] font-medium tabular-nums tracking-tight text-muted-foreground"
+        title="Request Number"
+      >
+        #{parts.idNum}
+      </span>
+
+      <span className="select-none text-border" aria-hidden>
+        |
+      </span>
+
+      <span
+        className="min-w-0 text-base font-semibold leading-snug tracking-tight text-foreground sm:text-lg"
+        title={parts.itemName === '—' ? undefined : parts.itemName}
+      >
+        <span className="line-clamp-2 break-words">{parts.itemName}</span>
+      </span>
+
+      <span className="select-none text-border/80" aria-hidden>
+        ·
+      </span>
+
+      <time
+        className="shrink-0 text-sm font-normal tabular-nums text-muted-foreground"
+        dateTime={parts.dateTimeAttr}
+        title="Requested Date"
+      >
+        {parts.dateDisplay}
+      </time>
     </div>
   );
 }

--- a/src/lib/recordModalHeader.ts
+++ b/src/lib/recordModalHeader.ts
@@ -3,6 +3,8 @@
  * Used by record table modals (detail, form edit, receive shipment).
  */
 
+import { formatCalendarDate } from '@/lib/timeUtils';
+
 export type RecordModalTitleInput = {
   id?: number | string | null;
   created_at?: string | null;
@@ -11,17 +13,8 @@ export type RecordModalTitleInput = {
 
 function formatModalHeaderDate(raw: unknown): string {
   if (raw == null || raw === '') return '—';
-  const s = String(raw).trim();
-  if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return s;
-  if (/^\d{4}-\d{2}-\d{2}T/.test(s)) {
-    const d = new Date(s);
-    if (!Number.isNaN(d.getTime())) return d.toISOString().slice(0, 10);
-  }
-  const d = new Date(s);
-  if (!Number.isNaN(d.getTime())) {
-    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
-  }
-  return s || '—';
+  const formatted = formatCalendarDate(String(raw).trim());
+  return !formatted || formatted === 'N/A' || formatted === 'Invalid date' ? '—' : formatted;
 }
 
 function dateTimeAttrFromRaw(raw: unknown): string | undefined {
@@ -46,6 +39,7 @@ export type RecordModalTitleParts = {
 
 /**
  * Parsed title segments for layout + plain string (`buildRecordModalTitle`).
+ * Order: Request Number → Item → Date.
  */
 export function getRecordModalTitleParts(
   record: RecordModalTitleInput | null | undefined,
@@ -74,5 +68,5 @@ export function getRecordModalTitleParts(
 export function buildRecordModalTitle(record: RecordModalTitleInput | null | undefined): string {
   const parts = getRecordModalTitleParts(record);
   if (!parts) return 'Record';
-  return `#${parts.idNum}, ${parts.itemName}, ${parts.dateDisplay}`;
+  return `#${parts.idNum} | ${parts.itemName} · ${parts.dateDisplay}`;
 }

--- a/src/lib/timeUtils.ts
+++ b/src/lib/timeUtils.ts
@@ -63,23 +63,30 @@ export const convertGMTtoIST = (
 
 /**
  * Format a date-only value (YYYY-MM-DD) as a calendar day without timezone shift.
+ * Example: 2026-07-24 → "24 July 2026"
  * Full timestamps still go through convertGMTtoIST.
  */
 export const formatCalendarDate = (dateString: string): string => {
   if (!dateString) return 'N/A';
   const trimmed = String(dateString).trim();
-  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})/.exec(trimmed);
   if (dateOnly) {
     const year = Number(dateOnly[1]);
     const month = Number(dateOnly[2]) - 1;
     const day = Number(dateOnly[3]);
     const local = new Date(year, month, day);
     if (Number.isNaN(local.getTime())) return 'Invalid date';
-    return local.toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
+    return local.toLocaleDateString('en-GB', {
       day: 'numeric',
+      month: 'long',
+      year: 'numeric',
     });
   }
-  return convertGMTtoIST(trimmed, 'date');
+  const formatted = convertGMTtoIST(trimmed, 'date', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+  // convertGMTtoIST may still append time; strip time portion if present.
+  return String(formatted).replace(/,?\s*\d{1,2}:\d{2}.*$/, '').trim() || formatted;
 };


### PR DESCRIPTION
Use a clearer #id | item · date title, format dates as 24 July 2026, and surface estimated cost, computed price, and product link in the request modal.