### PR TITLE
Show shipment tracking columns on My Request tables.

### DIFF
--- a/src/components/page-builder/InventoryTableComponent.tsx
+++ b/src/components/page-builder/InventoryTableComponent.tsx
@@ -16,14 +16,15 @@ interface RecordsTableProps {
  * Generic records table component for PageBuilder.
  * Backed by LeadTableComponent but not tied to any specific entity.
  *
- * For inventory_request tables:
+ * For inventory_request / unmannd_request tables:
  * - shipment tracking columns are merged when missing
  * - row click opens the form modal so built-in Approve / Reject / Order show
  *   (same as Procurement Table / Manager All Requests)
  */
 export const InventoryTableComponent: React.FC<RecordsTableProps> = ({ config }) => {
   const entityType = String(config?.entityType || '').trim();
-  const isInventoryRequest = entityType === 'inventory_request';
+  const isInventoryRequest =
+    entityType === 'inventory_request' || entityType === 'unmannd_request';
   const columns = isInventoryRequest
     ? mergeInventoryTrackingColumns(config?.columns)
     : config?.columns;

--- a/src/components/page-builder/MyRequestTableComponent.tsx
+++ b/src/components/page-builder/MyRequestTableComponent.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo } from 'react';
 import { LeadTableComponent } from './LeadTableComponent';
 import { resolvePriorityFromRow } from '@/lib/inventoryPriority';
+import { mergeInventoryTrackingColumns } from '@/lib/shipmentTracking';
 
 export type MyRequestTableColumn = {
   key: string;
@@ -64,16 +65,20 @@ function entityTypeFromEndpoint(apiEndpoint?: string): string | undefined {
 
 /**
  * My Request table for Page Builder.
- * Fully dynamic: columns, API endpoint, entity type, title — all from config.
- * Nothing is seeded or hardcoded.
+ * Columns come from config; for inventory/unmannd requests, shipment tracking
+ * columns are merged in the same way as All Requests / Procurement Table.
  */
 export const MyRequestTableComponent: React.FC<MyRequestTableProps> = ({ config }) => {
   const mergedConfig = useMemo(() => {
-    const columns = withPriorityTransform(config?.columns || []);
     const fromEndpoint = entityTypeFromEndpoint(config?.apiEndpoint);
     const entityType = config?.entityType || fromEndpoint;
     const isInventoryLike =
       entityType === 'inventory_request' || entityType === 'unmannd_request';
+    const columns = withPriorityTransform(
+      (isInventoryLike
+        ? mergeInventoryTrackingColumns(config?.columns || [])
+        : config?.columns || []) as MyRequestTableColumn[]
+    );
 
     return {
       ...(config || {}),


### PR DESCRIPTION
Merge the same inventory tracking columns used on All Requests so requestors see shipment status without Page Builder config.