### PR TITLE
Allow team leads to Approve/Reject including their own requests.

### DIFF
--- a/src/component-config/TableConfig.tsx
+++ b/src/component-config/TableConfig.tsx
@@ -266,8 +266,8 @@ export const TableConfig: React.FC<TableConfigProps> = ({
           <div className="space-y-2">
             <p className="text-sm font-medium">Inventory request flow</p>
             <p className="text-xs text-muted-foreground">
-              Manager pages: Approve/Reject/Send to requestor to verify on NEW_REQUEST. Team-lead pages: Order only on
-              VENDOR_IDENTIFIED (no Approve/Reject on new requests).
+              Team lead can Approve / Reject (including their own requests). PM can Approve / Reject other people&apos;s
+              requests only — on their own request they act like a requestor (Verify only).
             </p>
           </div>
           <div className="space-y-2">
@@ -288,13 +288,12 @@ export const TableConfig: React.FC<TableConfigProps> = ({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="auto">Auto (from user role)</SelectItem>
-                <SelectItem value="manager">Manager — Approve / Reject</SelectItem>
-                <SelectItem value="team_lead">Team lead — Order only</SelectItem>
+                <SelectItem value="team_lead">Team lead page</SelectItem>
+                <SelectItem value="manager">Manager / PM page</SelectItem>
               </SelectContent>
             </Select>
             <p className="text-xs text-muted-foreground">
-              Set <strong>Team lead — Order only</strong> on the team-lead All Requests page so new requests never
-              show Approve/Reject.
+              Used on All Requests tables. PM still cannot Approve a request they created.
             </p>
           </div>
           <Button type="button" variant="outline" size="sm" onClick={applySimpleInventoryDefaults}>

--- a/src/components/page-builder/InventoryFormEditModal.tsx
+++ b/src/components/page-builder/InventoryFormEditModal.tsx
@@ -109,10 +109,8 @@ interface InventoryFormEditModalProps {
   /** Whether to show the Save button in the footer. If undefined, Save shows only when there are no action buttons. */
   showSaveButton?: boolean;
   /**
-   * Inventory All Requests actor:
-   * - manager → Approve / Reject / Put on Hold
-   * - team_lead → Order only (no Approve / Reject on new requests)
-   * - auto → infer from membership role
+   * Inventory All Requests actor page. Team lead and PM both get Approve/Reject
+   * (including on their own requests). Mode is kept for Page Builder pages.
    */
   inventoryWorkflowMode?: 'auto' | 'manager' | 'team_lead';
   /** When set, show one button: conditional if attribute matches, else default (e.g. Inventory Payment modal). */
@@ -1246,6 +1244,15 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
     (record?.data && typeof record.data === 'object'
       ? (record.data as Record<string, unknown>).team_lead
       : undefined);
+  const managerFromForm =
+    formData.manager != null && String(formData.manager).trim() !== ''
+      ? formData.manager
+      : undefined;
+  const managerOnRecord =
+    managerFromForm ??
+    (record?.data && typeof record.data === 'object'
+      ? (record.data as Record<string, unknown>).manager
+      : undefined);
 
   const workflowButtons =
     isInventoryRequest && !isPaymentModal
@@ -1254,7 +1261,9 @@ export const InventoryFormEditModal: React.FC<InventoryFormEditModalProps> = ({
           roleNameOrKey: myRoleName,
           roleKey: myRoleKey,
           membershipId: myMembershipId,
+          userId: user?.id ?? null,
           teamLeadOnRecord,
+          managerOnRecord,
           isRequester,
           workflowMode: inventoryWorkflowMode ?? 'auto',
         })

--- a/src/components/page-builder/LeadTableComponent.tsx
+++ b/src/components/page-builder/LeadTableComponent.tsx
@@ -484,8 +484,14 @@ export const LeadTableComponent: React.FC<LeadTableProps> = ({ config, pageId })
     return 'lead_card';
   }, [config?.detailMode, config?.entityType]);
 
-  /** Use form-style modal when detail mode is record_form_modal, inventory_payment_modal, or when record detail modal type is form_edit. */
-  const useFormModal = effectiveDetailMode === 'record_form_modal' || effectiveDetailMode === 'inventory_payment_modal' || (effectiveDetailMode !== 'receive_shipments' && config?.recordDetailModalType === 'form_edit');
+  /** Use form-style modal when detail mode is record_form_modal, inventory_payment_modal, or form_edit.
+   * Always use form modal for inventory requests so Approve/Reject render in the footer. */
+  const useFormModal =
+    effectiveDetailMode === 'record_form_modal' ||
+    effectiveDetailMode === 'inventory_payment_modal' ||
+    (effectiveDetailMode !== 'receive_shipments' && config?.recordDetailModalType === 'form_edit') ||
+    (effectiveDetailMode !== 'receive_shipments' &&
+      (config?.entityType === 'inventory_request' || config?.entityType === 'unmannd_request'));
 
   // Memoize onLeadUpdate callback for modal to prevent infinite re-render loop
   const handleModalLeadUpdate = useCallback((updatedLead: any) => {

--- a/src/lib/inventoryWorkflow.test.ts
+++ b/src/lib/inventoryWorkflow.test.ts
@@ -2,170 +2,136 @@ import { describe, expect, it } from 'vitest';
 import {
   filterDuplicateInventoryWorkflowButtons,
   getInventoryWorkflowButtons,
+  isInventoryApproverActor,
   isInventoryProcurementRole,
   isInventoryTeamLeadRole,
 } from './inventoryWorkflow';
-import { shouldShowShipmentTrackingSection } from './shipmentTracking';
 
-describe('inventory procurement → order flow (existing statuses)', () => {
-  it('requestor never sees Approve/Reject/Order on non-verify statuses', () => {
+describe('inventory Approve/Reject for team lead and PM', () => {
+  it('plain requestor only gets Verify on REQ_TO_VERIFY', () => {
     expect(
       getInventoryWorkflowButtons({
         requestStatus: 'NEW_REQUEST',
         isRequester: true,
-        workflowMode: 'manager',
-      })
-    ).toEqual([]);
-    expect(
-      getInventoryWorkflowButtons({
-        requestStatus: 'VENDOR_IDENTIFIED',
-        isRequester: true,
-        workflowMode: 'team_lead',
-      })
-    ).toEqual([]);
-  });
-
-  it('requestor can Verify on REQ_TO_VERIFY only', () => {
-    expect(
-      getInventoryWorkflowButtons({
-        requestStatus: 'REQ_TO_VERIFY',
-        isRequester: true,
-        workflowMode: 'manager',
-      }).map((b) => [b.label, b.statusValue])
-    ).toEqual([['Verify', 'VENDOR_IDENTIFIED']]);
-
-    expect(
-      getInventoryWorkflowButtons({
-        requestStatus: 'ON_HOLD',
-        isRequester: true,
-      })
-    ).toEqual([]);
-  });
-
-  it('non-requestor cannot Verify on REQ_TO_VERIFY', () => {
-    expect(
-      getInventoryWorkflowButtons({
-        requestStatus: 'REQ_TO_VERIFY',
-        isRequester: false,
-        workflowMode: 'manager',
+        roleNameOrKey: 'Engineer',
       })
     ).toEqual([]);
     expect(
       getInventoryWorkflowButtons({
         requestStatus: 'REQ_TO_VERIFY',
-        isRequester: false,
-        workflowMode: 'team_lead',
-      })
-    ).toEqual([]);
-  });
-
-  it('manager can Approve / Send to verify / Reject / Put on Hold on NEW_REQUEST', () => {
-    const buttons = getInventoryWorkflowButtons({
-      requestStatus: 'NEW_REQUEST',
-      isRequester: false,
-      workflowMode: 'manager',
-    });
-    expect(buttons.map((b) => b.statusValue)).toEqual([
-      'VENDOR_IDENTIFIED',
-      'REQ_TO_VERIFY',
-      'REJECTED',
-      'ON_HOLD',
-    ]);
-    expect(buttons.map((b) => b.label)).toContain('Send to requestor to verify');
-  });
-
-  it('manager can Put on Hold on VENDOR_IDENTIFIED and resume from ON_HOLD', () => {
-    expect(
-      getInventoryWorkflowButtons({
-        requestStatus: 'VENDOR_IDENTIFIED',
-        isRequester: false,
-        workflowMode: 'manager',
-      }).map((b) => [b.label, b.statusValue])
-    ).toEqual([['Put on Hold', 'ON_HOLD']]);
-
-    expect(
-      getInventoryWorkflowButtons({
-        requestStatus: 'ON_HOLD',
-        isRequester: false,
-        workflowMode: 'manager',
-      }).map((b) => b.statusValue)
-    ).toEqual(['VENDOR_IDENTIFIED', 'REQ_TO_VERIFY', 'REJECTED']);
-  });
-
-  it('team lead never sees Approve/Reject on new requests', () => {
-    expect(
-      getInventoryWorkflowButtons({
-        requestStatus: 'NEW_REQUEST',
-        isRequester: false,
-        workflowMode: 'team_lead',
-        roleNameOrKey: 'Team Lead',
-      })
-    ).toEqual([]);
-  });
-
-  it('team lead sees Order on VENDOR_IDENTIFIED', () => {
-    for (const status of ['VENDOR_IDENTIFIED', 'VENDOR IDENTIFIED']) {
-      const buttons = getInventoryWorkflowButtons({
-        requestStatus: status,
-        roleNameOrKey: 'Team Lead',
-        workflowMode: 'team_lead',
-        isRequester: false,
-      });
-      expect(buttons.map((b) => [b.label, b.statusValue])).toEqual([['Order', 'IN_SHIPPING']]);
-    }
-  });
-
-  it('manager does not see Order (team-lead-only action)', () => {
-    expect(
-      getInventoryWorkflowButtons({
-        requestStatus: 'VENDOR_IDENTIFIED',
-        workflowMode: 'manager',
-        isRequester: false,
+        isRequester: true,
+        roleNameOrKey: 'Engineer',
       }).map((b) => b.label)
-    ).toEqual(['Put on Hold']);
+    ).toEqual(['Verify']);
   });
 
-  it('auto mode: team-lead role hides Approve; procurement role shows Approve', () => {
+  it('team lead can Approve/Reject on NEW_REQUEST', () => {
     expect(
       getInventoryWorkflowButtons({
         requestStatus: 'NEW_REQUEST',
-        roleNameOrKey: 'CSE Team Lead',
         isRequester: false,
-        workflowMode: 'auto',
-      })
-    ).toEqual([]);
-    expect(
-      getInventoryWorkflowButtons({
-        requestStatus: 'NEW_REQUEST',
-        roleNameOrKey: 'Procurement Manager',
-        isRequester: false,
-        workflowMode: 'auto',
+        roleNameOrKey: 'Team Lead',
       }).map((b) => b.label)
     ).toEqual(['Approve', 'Send to requestor to verify', 'Reject', 'Put on Hold']);
   });
 
-  it('recognizes procurement vs team-lead roles', () => {
-    expect(isInventoryProcurementRole('Procurement Manager')).toBe(true);
-    expect(isInventoryProcurementRole('team_lead')).toBe(false);
+  it('PM can Approve/Reject someone else\'s NEW_REQUEST', () => {
+    expect(
+      getInventoryWorkflowButtons({
+        requestStatus: 'NEW_REQUEST',
+        isRequester: false,
+        roleNameOrKey: 'Procurement Manager',
+      }).map((b) => b.label)
+    ).toEqual(['Approve', 'Send to requestor to verify', 'Reject', 'Put on Hold']);
+  });
+
+  it('team lead can Approve their own request', () => {
+    expect(
+      getInventoryWorkflowButtons({
+        requestStatus: 'NEW_REQUEST',
+        isRequester: true,
+        roleNameOrKey: 'CSE Team Lead',
+      }).map((b) => b.label)
+    ).toContain('Approve');
+  });
+
+  it('PM cannot Approve/Reject their own request (same as requestor)', () => {
+    expect(
+      getInventoryWorkflowButtons({
+        requestStatus: 'NEW_REQUEST',
+        isRequester: true,
+        roleNameOrKey: 'Procurement Manager',
+      })
+    ).toEqual([]);
+    expect(
+      getInventoryWorkflowButtons({
+        requestStatus: 'REQ_TO_VERIFY',
+        isRequester: true,
+        roleNameOrKey: 'Procurement Manager',
+      }).map((b) => b.label)
+    ).toEqual(['Verify']);
+    expect(
+      isInventoryApproverActor({
+        roleNameOrKey: 'Procurement Manager',
+        isRequester: true,
+      })
+    ).toBe(false);
+  });
+
+  it('assigned team_lead on record can Approve', () => {
+    expect(
+      getInventoryWorkflowButtons({
+        requestStatus: 'NEW_REQUEST',
+        isRequester: false,
+        membershipId: 10,
+        teamLeadOnRecord: 10,
+      }).map((b) => b.label)
+    ).toContain('Approve');
+  });
+
+  it('assigned manager on record can Approve others\' requests only', () => {
+    expect(
+      getInventoryWorkflowButtons({
+        requestStatus: 'NEW_REQUEST',
+        isRequester: false,
+        membershipId: 20,
+        managerOnRecord: 20,
+      }).map((b) => b.label)
+    ).toContain('Approve');
+    expect(
+      getInventoryWorkflowButtons({
+        requestStatus: 'NEW_REQUEST',
+        isRequester: true,
+        membershipId: 20,
+        managerOnRecord: 20,
+        roleNameOrKey: 'Procurement Manager',
+      })
+    ).toEqual([]);
+  });
+
+  it('team lead can Order on VENDOR_IDENTIFIED', () => {
+    expect(
+      getInventoryWorkflowButtons({
+        requestStatus: 'VENDOR_IDENTIFIED',
+        roleNameOrKey: 'Team Lead',
+      }).map((b) => b.label)
+    ).toEqual(['Put on Hold', 'Order']);
+  });
+
+  it('recognizes TL and PM roles', () => {
+    expect(isInventoryApproverActor({ roleNameOrKey: 'Team Lead' })).toBe(true);
+    expect(isInventoryApproverActor({ roleNameOrKey: 'Procurement Manager' })).toBe(true);
+    expect(isInventoryApproverActor({ roleNameOrKey: 'Engineer' })).toBe(false);
     expect(isInventoryTeamLeadRole('TL')).toBe(true);
-    expect(isInventoryTeamLeadRole('CSE Team Lead')).toBe(true);
+    expect(isInventoryProcurementRole('PM')).toBe(true);
   });
 
   it('filters duplicate Page Builder status buttons', () => {
-    const filtered = filterDuplicateInventoryWorkflowButtons([
-      { label: 'Approve vendor', statusValue: 'VENDOR_IDENTIFIED' },
-      { label: 'Send verify', statusValue: 'REQ_TO_VERIFY' },
-      { label: 'Custom', statusValue: 'SOME_CUSTOM' },
-    ]);
-    expect(filtered.map((b) => b.statusValue)).toEqual(['SOME_CUSTOM']);
-  });
-});
-
-describe('shipment tracking visibility', () => {
-  it('shows from VENDOR_IDENTIFIED / IN_SHIPPING', () => {
-    expect(shouldShowShipmentTrackingSection('NEW_REQUEST')).toBe(false);
-    expect(shouldShowShipmentTrackingSection('REQ_TO_VERIFY')).toBe(false);
-    expect(shouldShowShipmentTrackingSection('VENDOR_IDENTIFIED')).toBe(true);
-    expect(shouldShowShipmentTrackingSection('IN_SHIPPING')).toBe(true);
+    expect(
+      filterDuplicateInventoryWorkflowButtons([
+        { label: 'Approve', statusValue: 'VENDOR_IDENTIFIED' },
+        { label: 'Custom', statusValue: 'OTHER' },
+      ]).map((b) => b.statusValue)
+    ).toEqual(['OTHER']);
   });
 });

--- a/src/lib/inventoryWorkflow.ts
+++ b/src/lib/inventoryWorkflow.ts
@@ -1,26 +1,19 @@
 /**
- * Inventory request flow on the existing status architecture:
+ * Inventory request flow:
  *
- *   NEW_REQUEST
- *     → (manager Approve) VENDOR_IDENTIFIED
- *     → (manager Send to requestor to verify) REQ_TO_VERIFY
- *     → (manager Reject) REJECTED
- *     → (manager Put on Hold) ON_HOLD
- *   ON_HOLD
- *     → (manager Approve) VENDOR_IDENTIFIED
- *     → (manager Send to requestor to verify) REQ_TO_VERIFY
- *     → (manager Reject) REJECTED
+ *   NEW_REQUEST / ON_HOLD
+ *     → (team lead OR PM Approve) VENDOR_IDENTIFIED
+ *     → (team lead OR PM Reject / Send to verify / Hold)
  *   REQ_TO_VERIFY
  *     → (requestor Verify) VENDOR_IDENTIFIED
  *   VENDOR_IDENTIFIED
- *     → (team lead Order) IN_SHIPPING
- *     → (manager Put on Hold) ON_HOLD
- *   IN_SHIPPING → shipment tracking (paste link/AWB)
+ *     → (team lead OR PM Order / Hold)
  *
- * Page Builder can set inventoryWorkflowMode:
- *   - manager   → Approve / Reject / Put on Hold / Send to verify
- *   - team_lead → Order only (no Approve / Reject on new requests)
- *   - auto      → infer from membership role
+ * Rules:
+ * - Team lead can Approve/Reject, including on requests they created.
+ * - PM can Approve/Reject other people's requests, but NOT their own
+ *   (on their own request they are treated like a requestor).
+ * - Plain requestors only get Verify on REQ_TO_VERIFY.
  */
 
 export const INVENTORY_APPROVABLE_STATUSES = new Set([
@@ -28,18 +21,15 @@ export const INVENTORY_APPROVABLE_STATUSES = new Set([
   'ON_HOLD',
 ]);
 
-/** Statuses where a procurement manager can put the request on hold. */
 export const INVENTORY_HOLDABLE_STATUSES = new Set([
   'NEW_REQUEST',
   'VENDOR_IDENTIFIED',
 ]);
 
-/** Statuses where Order is available (moves request into shipping). */
 export const INVENTORY_ORDERABLE_STATUSES = new Set([
   'VENDOR_IDENTIFIED',
 ]);
 
-/** Page Builder status values that duplicate built-in workflow buttons. */
 export const INVENTORY_WORKFLOW_BUILTIN_STATUS_VALUES = new Set([
   'VENDOR_IDENTIFIED',
   'REQ_TO_VERIFY',
@@ -71,6 +61,16 @@ function normalizeStatus(status: unknown): string {
     .replace(/\s+/g, '_');
 }
 
+function idsMatch(
+  left: number | string | null | undefined,
+  right: unknown
+): boolean {
+  if (left == null || right == null || right === '') return false;
+  const a = String(left).trim();
+  const b = String(right).trim();
+  return !!a && !!b && a === b;
+}
+
 /** Team-lead-like role from membership role_key / role_name. */
 export function isInventoryTeamLeadRole(role: string | null | undefined): boolean {
   const r = normalizeRole(role);
@@ -82,7 +82,7 @@ export function isInventoryTeamLeadRole(role: string | null | undefined): boolea
   return false;
 }
 
-/** Procurement / manager-like roles (All Requests actors). */
+/** Procurement / manager-like roles. */
 export function isInventoryProcurementRole(role: string | null | undefined): boolean {
   const r = normalizeRole(role);
   if (!r) return false;
@@ -98,45 +98,67 @@ export function isInventoryProcurementRole(role: string | null | undefined): boo
   );
 }
 
-/**
- * True when the current user is the record's team_lead.
- * `team_lead` may be a tenant membership id or (legacy) auth user id.
- */
+/** True when the current user is the record's team_lead. */
 export function isAssignedInventoryTeamLead(
   membershipId: number | string | null | undefined,
   teamLeadOnRecord: unknown,
   userId?: number | string | null
 ): boolean {
-  if (teamLeadOnRecord == null || teamLeadOnRecord === '') return false;
-  const tl = String(teamLeadOnRecord).trim();
-  if (!tl) return false;
-  if (membershipId != null && String(membershipId).trim() === tl) return true;
-  if (userId != null && String(userId).trim() === tl) return true;
+  return idsMatch(membershipId, teamLeadOnRecord) || idsMatch(userId, teamLeadOnRecord);
+}
+
+/** True when the current user is the record's manager (PM). */
+export function isAssignedInventoryManager(
+  membershipId: number | string | null | undefined,
+  managerOnRecord: unknown,
+  userId?: number | string | null
+): boolean {
+  return idsMatch(membershipId, managerOnRecord) || idsMatch(userId, managerOnRecord);
+}
+
+function isTeamLeadActor(opts: {
+  roleNameOrKey?: string | null;
+  roleKey?: string | null;
+  membershipId?: number | string | null;
+  userId?: number | string | null;
+  teamLeadOnRecord?: unknown;
+}): boolean {
+  const roles = [opts.roleNameOrKey, opts.roleKey];
+  if (roles.some((r) => isInventoryTeamLeadRole(r))) return true;
+  return isAssignedInventoryTeamLead(opts.membershipId, opts.teamLeadOnRecord, opts.userId);
+}
+
+/** Team lead or PM — can Approve / Reject (PM excluded when acting as requestor). */
+export function isInventoryApproverActor(opts: {
+  roleNameOrKey?: string | null;
+  roleKey?: string | null;
+  membershipId?: number | string | null;
+  userId?: number | string | null;
+  teamLeadOnRecord?: unknown;
+  managerOnRecord?: unknown;
+  workflowMode?: InventoryWorkflowMode | null;
+  isRequester?: boolean;
+}): boolean {
+  const isTl = isTeamLeadActor(opts);
+  // Team lead may Approve even on their own request.
+  if (isTl) return true;
+
+  // PM (and anyone else) cannot Approve/Reject a request they created.
+  if (opts.isRequester) return false;
+
+  const roles = [opts.roleNameOrKey, opts.roleKey];
+  if (roles.some((r) => isInventoryProcurementRole(r))) return true;
+  if (isAssignedInventoryManager(opts.membershipId, opts.managerOnRecord, opts.userId)) {
+    return true;
+  }
+  if (opts.workflowMode === 'manager' || opts.workflowMode === 'team_lead') return true;
   return false;
 }
 
-function resolveWorkflowMode(opts: {
-  workflowMode?: InventoryWorkflowMode | null;
-  roleNameOrKey?: string | null;
-  roleKey?: string | null;
-}): 'manager' | 'team_lead' {
-  if (opts.workflowMode === 'manager' || opts.workflowMode === 'team_lead') {
-    return opts.workflowMode;
-  }
-  const roles = [opts.roleNameOrKey, opts.roleKey];
-  if (roles.some((r) => isInventoryTeamLeadRole(r))) return 'team_lead';
-  if (roles.some((r) => isInventoryProcurementRole(r))) return 'manager';
-  // Unknown role: default to manager-style approve (safe for Manager All Requests).
-  // Team-lead pages should set inventoryWorkflowMode=team_lead in Page Builder.
-  return 'manager';
-}
-
 /**
- * Built-in Approve / Reject / Put on Hold / Send to verify / Order / Verify for the record form modal.
- *
- * Manager: Approve/Reject/Send-to-verify on NEW_REQUEST or ON_HOLD; Put on Hold on open requests.
- * Requestor: Verify on REQ_TO_VERIFY only.
- * Team lead: Order on VENDOR_IDENTIFIED (never Approve/Reject).
+ * Built-in workflow buttons.
+ * Team lead: Approve/Reject (including own requests).
+ * PM: Approve/Reject others' requests only — own requests = requestor (Verify only).
  */
 export function getInventoryWorkflowButtons(opts: {
   requestStatus: unknown;
@@ -145,15 +167,16 @@ export function getInventoryWorkflowButtons(opts: {
   membershipId?: number | string | null;
   userId?: number | string | null;
   teamLeadOnRecord?: unknown;
+  managerOnRecord?: unknown;
   isRequester?: boolean;
-  /** Page-level override: manager All Requests vs team-lead All Requests. */
   workflowMode?: InventoryWorkflowMode | null;
 }): InventoryWorkflowActionButton[] {
   const status = normalizeStatus(opts.requestStatus);
   const buttons: InventoryWorkflowActionButton[] = [];
+  const isApprover = isInventoryApproverActor(opts);
 
-  if (opts.isRequester) {
-    if (status === 'REQ_TO_VERIFY') {
+  if (!isApprover) {
+    if (opts.isRequester && status === 'REQ_TO_VERIFY') {
       buttons.push({
         label: 'Verify',
         statusValue: 'VENDOR_IDENTIFIED',
@@ -163,9 +186,7 @@ export function getInventoryWorkflowButtons(opts: {
     return buttons;
   }
 
-  const mode = resolveWorkflowMode(opts);
-
-  if (mode === 'manager' && INVENTORY_APPROVABLE_STATUSES.has(status)) {
+  if (INVENTORY_APPROVABLE_STATUSES.has(status)) {
     buttons.push(
       {
         label: 'Approve',
@@ -181,7 +202,7 @@ export function getInventoryWorkflowButtons(opts: {
     );
   }
 
-  if (mode === 'manager' && INVENTORY_HOLDABLE_STATUSES.has(status)) {
+  if (INVENTORY_HOLDABLE_STATUSES.has(status)) {
     buttons.push({
       label: 'Put on Hold',
       statusValue: 'ON_HOLD',
@@ -189,7 +210,7 @@ export function getInventoryWorkflowButtons(opts: {
     });
   }
 
-  if (mode === 'team_lead' && INVENTORY_ORDERABLE_STATUSES.has(status)) {
+  if (INVENTORY_ORDERABLE_STATUSES.has(status)) {
     buttons.push({
       label: 'Order',
       statusValue: 'IN_SHIPPING',


### PR DESCRIPTION
PMs can Approve others' requests but are treated like requestors on requests they created; inventory tables always open the form modal so workflow buttons render.