### PR TITLE
Default inventory price-compare profile to core.

### DIFF
--- a/src/components/page-builder/InventoryRequestFormComponent.tsx
+++ b/src/components/page-builder/InventoryRequestFormComponent.tsx
@@ -641,8 +641,8 @@ export const InventoryRequestFormComponent: React.FC<InventoryRequestFormProps> 
   const [ecommerceSources, setEcommerceSources] = useState<EcommerceSource[]>(() => [
     ...FALLBACK_ECOMMERCE_SOURCES,
   ]);
-  /** core = small reliable set; extended = full catalog (default). */
-  const [priceCompareProfile, setPriceCompareProfile] = useState<'core' | 'extended'>('extended');
+  /** core = small reliable set (default); extended = full catalog. */
+  const [priceCompareProfile, setPriceCompareProfile] = useState<'core' | 'extended'>('core');
   /** Per-item loading state for live marketplace price fetch. */
   const [liveCompareLoadingByItemId, setLiveCompareLoadingByItemId] = useState<Record<string, boolean>>({});
   /** Per-item loading while resolving product details from a pasted item link. */
@@ -851,7 +851,7 @@ export const InventoryRequestFormComponent: React.FC<InventoryRequestFormProps> 
           .filter((v) => v.id && v.label);
         if (cancelled || rows.length === 0) return;
         setEcommerceSources([...rows, { id: 'other', label: 'Other', vendorName: '', hostIncludes: [] }]);
-        // Form default is Extended; do not overwrite from API (settings used to force core).
+        // Form default is Core; keep local selection unless the user changes the profile control.
       } catch {
         // Keep fallback sources.
       }


### PR DESCRIPTION
Prefer the smaller reliable vendor set on the request form unless the user switches to extended.