### PR TITLE
Add Background Jobs page for manual enqueue and re-run.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import UserHierarchyPage from "./pages/UserHierarchyPage";
 import BillingPage from "./pages/BillingPage";
 import EntityTypesPage from "./pages/EntityTypesPage";
 import BackgroundJobsPage from "./pages/BackgroundJobsPage";
+import PyroJobsPage from "./pages/PyroJobsPage";
 const queryClient = new QueryClient();
 const App = () => (
   <QueryClientProvider client={queryClient}>
@@ -82,6 +83,7 @@ const App = () => (
             <Route path="/billing" element={<BillingPage />} />
             <Route path="/entity-types" element={<EntityTypesPage />} />
             <Route path="/background-jobs" element={<BackgroundJobsPage />} />
+            <Route path="/pyro-jobs" element={<PyroJobsPage />} />
           </Route>
 
           {/* Custom App Routes */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import OperationsProgramsPage from "./pages/OperationsProgramsPage";
 import UserHierarchyPage from "./pages/UserHierarchyPage";
 import BillingPage from "./pages/BillingPage";
 import EntityTypesPage from "./pages/EntityTypesPage";
+import BackgroundJobsPage from "./pages/BackgroundJobsPage";
 const queryClient = new QueryClient();
 const App = () => (
   <QueryClientProvider client={queryClient}>
@@ -80,6 +81,7 @@ const App = () => (
             <Route path="/user-hierarchy" element={<UserHierarchyPage />} />
             <Route path="/billing" element={<BillingPage />} />
             <Route path="/entity-types" element={<EntityTypesPage />} />
+            <Route path="/background-jobs" element={<BackgroundJobsPage />} />
           </Route>
 
           {/* Custom App Routes */}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
-import { Home, Layout, Sparkles, UserPlus, Database, Users, Receipt, TableProperties, Workflow } from "lucide-react";
+import { Home, Layout, Sparkles, UserPlus, Database, Users, Receipt, TableProperties, Workflow, Timer } from "lucide-react";
 import {
   Sidebar as SidebarComponent,
   SidebarContent,
@@ -42,6 +42,11 @@ const sidebarItems = [
     title: "Background Jobs",
     path: "/background-jobs",
     icon: Workflow,
+  },
+  {
+    title: "Pyro Jobs",
+    path: "/pyro-jobs",
+    icon: Timer,
   },
   {
     title: "Add User",

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
-import { Home, Layout, Sparkles, UserPlus, Database, Users, Receipt, TableProperties } from "lucide-react";
+import { Home, Layout, Sparkles, UserPlus, Database, Users, Receipt, TableProperties, Workflow } from "lucide-react";
 import {
   Sidebar as SidebarComponent,
   SidebarContent,
@@ -37,6 +37,11 @@ const sidebarItems = [
     title: "Entity Types",
     path: "/entity-types",
     icon: TableProperties,
+  },
+  {
+    title: "Background Jobs",
+    path: "/background-jobs",
+    icon: Workflow,
   },
   {
     title: "Add User",

--- a/src/components/page-builder/TicketCarousel.tsx
+++ b/src/components/page-builder/TicketCarousel.tsx
@@ -23,7 +23,6 @@ import {
   PieChart,
   Coffee,
   Waypoints,
-  MoreVertical,
   RefreshCw,
   Play,
   Pause,
@@ -39,12 +38,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { PendingTicketsCard, TicketStats } from "@/components/ui/PendingTicketsCard";
 import { SupportTicketTaskProgress } from "@/components/page-builder/SupportTicketTaskProgress";
 import { cn } from "@/lib/utils";

--- a/src/lib/backgroundJobsApi.ts
+++ b/src/lib/backgroundJobsApi.ts
@@ -1,0 +1,231 @@
+import { apiClient } from "@/lib/api";
+
+export interface ManualJobRunResult {
+  id: number;
+  job_type: string;
+  status: string;
+  tenant_id?: string | null;
+  source_job_id?: number;
+  payload?: Record<string, unknown>;
+  message?: string;
+}
+
+const JOB_PAYLOAD_TEMPLATES: Record<string, Record<string, unknown>> = {
+  send_mixpanel_event: {
+    user_id: 3181247,
+    event_name: "pyro_st_resolve",
+    properties: {},
+  },
+  send_rm_assigned_event: {
+    praja_id: 3181247,
+    rm_email: "rm@example.com",
+  },
+  send_cse_assigned_event: {
+    user_id: 3181247,
+    cse_email: "cse@example.com",
+  },
+  send_webhook: {
+    url: "https://example.com/webhook",
+    payload: {},
+  },
+  score_leads: {
+    entity_type: "lead",
+    batch_size: 500,
+  },
+  score_leads_chunk: {
+    entity_type: "lead",
+    id_gte: 1,
+    id_lt: 1000,
+    rules: [],
+    parent_job_id: 0,
+    chunk_index: 0,
+    total_chunks: 1,
+  },
+  send_to_praja: {
+    object_type: "save_resolved_ticket",
+    user_id: 3181247,
+    ticket_id: 1419024,
+    ticket_type: "self_trial",
+    ticket_status: "RESOLVED",
+    all_tasks_completed: false,
+  },
+  partner_lead_assign: {
+    tenant_id: "tenant-uuid",
+    email_id: "partner.user@example.com",
+    record_id: 12345,
+    partner_slug: "halocom",
+  },
+  unassign_snoozed_leads: {},
+  release_leads_after_12h: {},
+  close_stale_self_trial_support_tickets: {
+    days: 15,
+    other_days: 3,
+  },
+  snoozed_to_not_connected_midnight: {},
+  purge_old_log_tables: {
+    days: 30,
+    chunk_size: 1000,
+    max_chunks_per_table: 20,
+  },
+  sync_dispatch_to_records: {},
+  process_dumped_tickets: {},
+  discover_entity_types: {},
+  refresh_inventory_shipment_tracking: {},
+};
+
+export function getJobPayloadTemplate(jobType: string): Record<string, unknown> {
+  return JOB_PAYLOAD_TEMPLATES[jobType]
+    ? JSON.parse(JSON.stringify(JOB_PAYLOAD_TEMPLATES[jobType]))
+    : {};
+}
+
+export async function listRunnableJobTypes(): Promise<string[]> {
+  try {
+    const base = apiClient.defaults.baseURL || "";
+    console.log("[BOB Jobs API] GET", `${base}/jobs/types/`);
+    const response = await apiClient.get("/jobs/types/");
+    console.log("[BOB Jobs API] GET /jobs/types/ ->", response.status, response.data);
+    return Array.isArray(response.data?.job_types) ? response.data.job_types : [];
+  } catch (error: any) {
+    console.error("[BOB Jobs API] GET /jobs/types/ failed:", error?.response?.status, error?.response?.data);
+    throw error;
+  }
+}
+
+export async function enqueueBackgroundJob(params: {
+  jobType: string;
+  payload: Record<string, unknown>;
+  priority?: number;
+  maxAttempts?: number;
+  tenantId?: string;
+}): Promise<ManualJobRunResult> {
+  const base = apiClient.defaults.baseURL || "";
+  console.log("[BOB Jobs API] POST", `${base}/jobs/enqueue/`, {
+    job_type: params.jobType,
+    payload: params.payload,
+    priority: params.priority ?? 0,
+    max_attempts: params.maxAttempts ?? 3,
+    tenant_id: params.tenantId || undefined,
+  });
+  const response = await apiClient.post("/jobs/enqueue/", {
+    job_type: params.jobType,
+    payload: params.payload,
+    priority: params.priority ?? 0,
+    max_attempts: params.maxAttempts ?? 3,
+    tenant_id: params.tenantId || undefined,
+  });
+  console.log("[BOB Jobs API] POST /jobs/enqueue/ ->", response.status, response.data);
+  return response.data;
+}
+
+export async function rerunBackgroundJob(
+  jobId: string | number,
+  tenantId?: string,
+): Promise<ManualJobRunResult> {
+  const base = apiClient.defaults.baseURL || "";
+  const rerunUrl = `/jobs/${jobId}/rerun/`;
+  const retryUrl = `/jobs/${jobId}/retry/`;
+  try {
+    console.log("[BOB Jobs API] POST", `${base}${rerunUrl}`, {
+      tenant_id: tenantId || undefined,
+    });
+    const response = await apiClient.post(rerunUrl, {
+      tenant_id: tenantId || undefined,
+    });
+    console.log("[BOB Jobs API] POST rerun ->", response.status, response.data);
+    return response.data;
+  } catch (error: any) {
+    const status = error?.response?.status;
+    console.error("[BOB Jobs API] rerun failed:", {
+      endpoint: `${base}${rerunUrl}`,
+      responseStatus: status,
+      responseData: error?.response?.data,
+      message: error?.message,
+      code: error?.code,
+      isAxiosError: error?.isAxiosError,
+    });
+    // Also print the full error for debugging (kept small-ish by browsers/devtools).
+    console.error(error);
+    // If rerun endpoint isn't deployed yet, fall back to retry endpoint.
+    if (status === 404) {
+      console.log("[BOB Jobs API] POST fallback retry", `${base}${retryUrl}`);
+      const retryResp = await apiClient.post(retryUrl, {
+        tenant_id: tenantId || undefined,
+      });
+      console.log("[BOB Jobs API] POST retry ->", retryResp.status, retryResp.data);
+      return retryResp.data;
+    }
+    throw error;
+  }
+}
+
+export async function getBackgroundJobStatus(
+  jobId: string | number,
+  tenantId?: string,
+): Promise<any> {
+  const base = apiClient.defaults.baseURL || "";
+  const url = `/jobs/${jobId}/`;
+  try {
+    console.log("[BOB Jobs API] GET job detail", {
+      endpoint: `${base}${url}`,
+      jobId,
+      tenantId: tenantId || undefined,
+    });
+    const response = await apiClient.get(url, {
+      params: tenantId ? { tenant_id: tenantId } : undefined,
+    });
+    console.log("[BOB Jobs API] GET job detail success", {
+      endpoint: `${base}${url}`,
+      status: response.status,
+      data: response.data,
+    });
+    return response.data;
+  } catch (error: any) {
+    console.error("[BOB Jobs API] GET job detail failed", {
+      endpoint: `${base}${url}`,
+      jobId,
+      message: error?.message,
+      name: error?.name,
+      status: error?.status,
+      data: error?.data,
+      responseStatus: error?.response?.status,
+      responseData: error?.response?.data,
+    });
+    throw error;
+  }
+}
+
+export async function enqueueCseAssignedJob(params: {
+  userId: string | number;
+  cseEmail: string;
+}): Promise<ManualJobRunResult> {
+  const response = await apiClient.post("/jobs/enqueue/", {
+    job_type: "send_cse_assigned_event",
+    payload: {
+      user_id: Number(params.userId),
+      cse_email: params.cseEmail,
+    },
+  });
+  return response.data;
+}
+
+export async function enqueueSaveSupportTicketJob(params: {
+  userId: string | number;
+  ticketId: string | number;
+  ticketType: string;
+  ticketStatus: string;
+  allTasksCompleted: boolean;
+}): Promise<ManualJobRunResult> {
+  const response = await apiClient.post("/jobs/enqueue/", {
+    job_type: "send_to_praja",
+    payload: {
+      object_type: "save_resolved_ticket",
+      user_id: Number(params.userId),
+      ticket_id: Number(params.ticketId),
+      ticket_type: params.ticketType,
+      ticket_status: params.ticketStatus,
+      all_tasks_completed: params.allTasksCompleted,
+    },
+  });
+  return response.data;
+}

--- a/src/lib/pyroJobsApi.ts
+++ b/src/lib/pyroJobsApi.ts
@@ -1,0 +1,66 @@
+import { apiClient } from "@/lib/api";
+
+export interface ManualPyroJobRunResult {
+  id: number;
+  job_name: string;
+  status: string;
+  payload?: Record<string, unknown>;
+  source_job_id?: number;
+  run_at?: string | null;
+  ran_pending_jobs?: Array<{
+    id: number;
+    status: string;
+    result?: Record<string, unknown> | null;
+    error?: string | null;
+  }>;
+  message?: string;
+}
+
+const PYRO_JOB_PAYLOAD_TEMPLATES: Record<string, Record<string, unknown>> = {
+  dispatch_data_sync: {},
+  purge_old_log_tables: {
+    days: 30,
+    chunk_size: 1000,
+    max_chunks_per_table: 20,
+  },
+  snoozed_to_not_connected_midnight: {},
+};
+
+export function getPyroJobPayloadTemplate(jobName: string): Record<string, unknown> {
+  return PYRO_JOB_PAYLOAD_TEMPLATES[jobName]
+    ? JSON.parse(JSON.stringify(PYRO_JOB_PAYLOAD_TEMPLATES[jobName]))
+    : {};
+}
+
+export async function listRunnablePyroJobTypes(): Promise<string[]> {
+  const response = await apiClient.get("/pyro-jobs/types/");
+  return Array.isArray(response.data?.job_types) ? response.data.job_types : [];
+}
+
+export async function enqueuePyroJob(params: {
+  jobName: string;
+  payload: Record<string, unknown>;
+  maxAttempts?: number;
+  tenantId?: string;
+}): Promise<ManualPyroJobRunResult> {
+  const payload = { ...params.payload };
+  if (params.tenantId && payload.tenant_id == null) {
+    payload.tenant_id = params.tenantId;
+  }
+  const response = await apiClient.post("/pyro-jobs/enqueue/", {
+    job_name: params.jobName,
+    payload,
+    max_attempts: params.maxAttempts ?? 3,
+  });
+  return response.data;
+}
+
+export async function getPyroJobStatus(jobId: string | number): Promise<any> {
+  const response = await apiClient.get(`/pyro-jobs/${jobId}/`);
+  return response.data;
+}
+
+export async function rerunPyroJob(jobId: string | number): Promise<ManualPyroJobRunResult> {
+  const response = await apiClient.post(`/pyro-jobs/${jobId}/rerun/`);
+  return response.data;
+}

--- a/src/pages/BackgroundJobsPage.tsx
+++ b/src/pages/BackgroundJobsPage.tsx
@@ -1,0 +1,402 @@
+import React, { useEffect, useMemo, useState } from "react";
+import DashboardLayout from "@/components/layout/DashboardLayout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { CustomButton } from "@/components/ui/CustomButton";
+import { useTenant } from "@/hooks/useTenant";
+import {
+  enqueueBackgroundJob,
+  getJobPayloadTemplate,
+  getBackgroundJobStatus,
+  listRunnableJobTypes,
+  rerunBackgroundJob,
+} from "@/lib/backgroundJobsApi";
+import { toast } from "sonner";
+import { PlayCircle, RefreshCw } from "lucide-react";
+
+const ALLOWED_ROLE_KEYS = new Set(["PYRO_ADMIN", "GM", "ASM", "OWNER", "ADMIN"]);
+
+const BackgroundJobsPage: React.FC = () => {
+  const { customRole, membershipLoaded, tenantId } = useTenant();
+  const [selectedJobType, setSelectedJobType] = useState("");
+  const [jobPayload, setJobPayload] = useState("{\n  \n}");
+  const [selectedTenantId, setSelectedTenantId] = useState("");
+  const [rerunJobId, setRerunJobId] = useState("");
+  const [resolvedRerunTenantId, setResolvedRerunTenantId] = useState("");
+  const [jobTypes, setJobTypes] = useState<string[]>([]);
+  const [loadingJobTypes, setLoadingJobTypes] = useState(false);
+  const [resolvingRerunTenant, setResolvingRerunTenant] = useState(false);
+  const [runningJob, setRunningJob] = useState<"generic" | "rerun" | null>(null);
+
+  const formatTemplate = (jobType: string) =>
+    JSON.stringify(getJobPayloadTemplate(jobType), null, 2);
+
+  const normalizedRole = useMemo(
+    () => String(customRole || "").trim().toUpperCase(),
+    [customRole],
+  );
+  const hasAccess = membershipLoaded && ALLOWED_ROLE_KEYS.has(normalizedRole);
+
+  useEffect(() => {
+    if (!hasAccess) return;
+    let active = true;
+    const loadJobTypes = async () => {
+      setLoadingJobTypes(true);
+      try {
+        const types = await listRunnableJobTypes();
+        if (!active) return;
+        setJobTypes(types);
+        setSelectedJobType((current) => current || types[0] || "");
+      } catch (error: any) {
+        if (!active) return;
+        toast.error(error?.message || "Failed to load job types");
+      } finally {
+        if (active) setLoadingJobTypes(false);
+      }
+    };
+    void loadJobTypes();
+    return () => {
+      active = false;
+    };
+  }, [hasAccess]);
+
+  useEffect(() => {
+    if (!selectedJobType) return;
+    setJobPayload(formatTemplate(selectedJobType));
+  }, [selectedJobType]);
+
+  useEffect(() => {
+    if (tenantId && !selectedTenantId) {
+      setSelectedTenantId(tenantId);
+    }
+  }, [tenantId, selectedTenantId]);
+
+  useEffect(() => {
+    const trimmedJobId = rerunJobId.trim();
+    if (!trimmedJobId) {
+      setResolvedRerunTenantId("");
+      setResolvingRerunTenant(false);
+      return;
+    }
+
+    let cancelled = false;
+    const timeoutId = window.setTimeout(async () => {
+      setResolvingRerunTenant(true);
+      try {
+        const detail = await getBackgroundJobStatus(trimmedJobId);
+        if (cancelled) return;
+        const resolvedTenant = String(detail?.tenant_id || "");
+        setResolvedRerunTenantId(resolvedTenant);
+        console.log("[BOB Jobs Page] auto-resolved rerun tenant", {
+          jobId: trimmedJobId,
+          tenantId: detail?.tenant_id,
+          jobType: detail?.job_type,
+          status: detail?.status,
+        });
+        if (!resolvedTenant) {
+          toast.error("Job found, but it has no tenant_id set");
+        }
+      } catch (err: any) {
+        if (cancelled) return;
+        setResolvedRerunTenantId("");
+        console.error("[BOB Jobs Page] auto-resolve rerun tenant failed", {
+          jobId: trimmedJobId,
+          message: err?.message,
+          name: err?.name,
+          status: err?.status,
+          data: err?.data,
+        });
+      } finally {
+        if (!cancelled) setResolvingRerunTenant(false);
+      }
+    }, 500);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [rerunJobId]);
+
+  const runGenericJob = async () => {
+    if (!selectedJobType.trim()) {
+      toast.error("Select a job type");
+      return;
+    }
+
+    let parsedPayload: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(jobPayload);
+      if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
+        toast.error("Payload must be a JSON object");
+        return;
+      }
+      parsedPayload = parsed as Record<string, unknown>;
+    } catch {
+      toast.error("Payload is not valid JSON");
+      return;
+    }
+
+    console.log("[BOB Jobs Page] runGenericJob", {
+      selectedJobType,
+      parsedPayload,
+      selectedTenantId,
+    });
+    setRunningJob("generic");
+    try {
+      const result = await enqueueBackgroundJob({
+        jobType: selectedJobType,
+        payload: parsedPayload,
+        tenantId: selectedTenantId.trim() || undefined,
+      });
+      toast.success(
+        `${selectedJobType} queued as job #${result.id}${result.tenant_id ? ` for tenant ${result.tenant_id}` : ""}`,
+      );
+    } catch (error: any) {
+      toast.error(
+        error?.response?.data?.error ||
+          error?.message ||
+          `Failed to queue ${selectedJobType}`,
+      );
+    } finally {
+      setRunningJob(null);
+    }
+  };
+
+  const runRerunJob = async () => {
+    if (!rerunJobId.trim()) {
+      toast.error("Enter a job ID to re-run");
+      return;
+    }
+    console.log("[BOB Jobs Page] runRerunJob start", {
+      rerunJobId,
+      resolvedRerunTenantId,
+      normalizedRole,
+      hasAccess,
+    });
+    setRunningJob("rerun");
+    try {
+      // Pre-check so we can show a clearer message when the job
+      // doesn't exist (or doesn't belong to the current tenant).
+      try {
+        console.log("[BOB Jobs Page] checking job before rerun", {
+          jobId: rerunJobId.trim(),
+        });
+        const detail = await getBackgroundJobStatus(rerunJobId.trim());
+        if (detail?.tenant_id) {
+          setResolvedRerunTenantId(String(detail.tenant_id));
+        }
+        console.log("[BOB Jobs Page] job detail check passed", {
+          jobId: rerunJobId.trim(),
+          tenantId: detail?.tenant_id,
+        });
+      } catch (err: any) {
+        const msg = String(err?.message || "");
+        console.error("[BOB Jobs Page] job detail check failed", {
+          jobId: rerunJobId.trim(),
+          message: err?.message,
+          name: err?.name,
+          status: err?.status,
+          data: err?.data,
+        });
+        if (msg.toLowerCase().includes("job not found")) {
+          toast.error(
+            "Job not found across tenants. Confirm this is a BackgroundJob ID (not a ticket/record ID)."
+          );
+          return;
+        }
+        throw err;
+      }
+
+      const result = await rerunBackgroundJob(
+        rerunJobId.trim(),
+        resolvedRerunTenantId.trim() || undefined,
+      );
+      console.log("[BOB Jobs Page] rerun succeeded", {
+        sourceJobId: rerunJobId.trim(),
+        tenantId: resolvedRerunTenantId,
+        newJobId: result.id,
+        result,
+      });
+      toast.success(`Job requeued as new job #${result.id}`);
+    } catch (error: any) {
+      console.error("[BOB Jobs Page] rerun failed", {
+        jobId: rerunJobId.trim(),
+        message: error?.message,
+        name: error?.name,
+        status: error?.status,
+        data: error?.data,
+        responseStatus: error?.response?.status,
+        responseData: error?.response?.data,
+      });
+      toast.error(
+        error?.response?.data?.error ||
+          error?.message ||
+          "Failed to re-run job",
+      );
+    } finally {
+      setRunningJob(null);
+    }
+  };
+
+  if (!membershipLoaded) {
+    return (
+      <DashboardLayout>
+        <div className="text-sm text-muted-foreground">Loading access...</div>
+      </DashboardLayout>
+    );
+  }
+
+  if (!hasAccess) {
+    return (
+      <DashboardLayout>
+        <Card>
+          <CardHeader>
+            <CardTitle>Background Jobs</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            You do not have access to manually run background jobs.
+          </CardContent>
+        </Card>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Background Jobs</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Run any registered background job from BOB and view the queuing result.
+          </p>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <PlayCircle className="h-5 w-5" />
+                Run Any Background Job
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="job-type">Job Type</Label>
+                <Select
+                  value={selectedJobType}
+                  onValueChange={setSelectedJobType}
+                  disabled={loadingJobTypes || runningJob === "generic"}
+                >
+                  <SelectTrigger id="job-type">
+                    <SelectValue placeholder={loadingJobTypes ? "Loading job types..." : "Select a job type"} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {jobTypes.map((jobType) => (
+                      <SelectItem key={jobType} value={jobType}>
+                        {jobType}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="job-tenant-id">Tenant ID</Label>
+                <Input
+                  id="job-tenant-id"
+                  value={selectedTenantId}
+                  onChange={(e) => setSelectedTenantId(e.target.value)}
+                  placeholder={tenantId || "Tenant UUID"}
+                  disabled={runningJob === "generic"}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Defaults to your current tenant. Override this when you need to queue the job for another tenant.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <Label htmlFor="job-payload">Payload JSON</Label>
+                  <CustomButton
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setJobPayload(formatTemplate(selectedJobType))}
+                    disabled={!selectedJobType || runningJob === "generic"}
+                  >
+                    Reset to template
+                  </CustomButton>
+                </div>
+                <Textarea
+                  id="job-payload"
+                  value={jobPayload}
+                  onChange={(e) => setJobPayload(e.target.value)}
+                  className="min-h-[220px] font-mono text-sm"
+                  placeholder="Select a job type to load its payload template"
+                />
+              </div>
+              <CustomButton
+                onClick={runGenericJob}
+                loading={runningJob === "generic"}
+                className="w-full"
+              >
+                Run Selected Job
+              </CustomButton>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <RefreshCw className="h-5 w-5" />
+                Re-run Existing Job
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="rerun-job-id">Job ID</Label>
+                <Input
+                  id="rerun-job-id"
+                  value={rerunJobId}
+                  onChange={(e) => setRerunJobId(e.target.value)}
+                  placeholder="7114764"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="rerun-tenant-id">Tenant ID</Label>
+                <Input
+                  id="rerun-tenant-id"
+                  value={resolvedRerunTenantId}
+                  readOnly
+                  placeholder={resolvingRerunTenant ? "Resolving tenant..." : "Will auto-fill from job ID"}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Enter a BackgroundJob ID. For privileged roles, the tenant is looked up across all tenants and filled here automatically.
+                </p>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                This clones the original job into a new pending job without editing the source job.
+              </p>
+              <CustomButton
+                onClick={runRerunJob}
+                loading={runningJob === "rerun"}
+                className="w-full"
+              >
+                Re-run Job by ID
+              </CustomButton>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default BackgroundJobsPage;

--- a/src/pages/PyroJobsPage.tsx
+++ b/src/pages/PyroJobsPage.tsx
@@ -14,18 +14,18 @@ import {
 import { CustomButton } from "@/components/ui/CustomButton";
 import { useTenant } from "@/hooks/useTenant";
 import {
-  enqueueBackgroundJob,
-  getJobPayloadTemplate,
-  getBackgroundJobStatus,
-  listRunnableJobTypes,
-  rerunBackgroundJob,
-} from "@/lib/backgroundJobsApi";
+  enqueuePyroJob,
+  getPyroJobPayloadTemplate,
+  getPyroJobStatus,
+  listRunnablePyroJobTypes,
+  rerunPyroJob,
+} from "@/lib/pyroJobsApi";
 import { toast } from "sonner";
 import { PlayCircle, RefreshCw } from "lucide-react";
 
 const ALLOWED_ROLE_KEYS = new Set(["PYRO_ADMIN", "GM", "ASM", "OWNER", "ADMIN"]);
 
-const BackgroundJobsPage: React.FC = () => {
+const PyroJobsPage: React.FC = () => {
   const { customRole, membershipLoaded, tenantId } = useTenant();
   const [selectedJobType, setSelectedJobType] = useState("");
   const [jobPayload, setJobPayload] = useState("{\n  \n}");
@@ -33,14 +33,14 @@ const BackgroundJobsPage: React.FC = () => {
   const [rerunJobId, setRerunJobId] = useState("");
   const [resolvedJobName, setResolvedJobName] = useState("");
   const [resolvedJobStatus, setResolvedJobStatus] = useState("");
-  const [resolvedRerunTenantId, setResolvedRerunTenantId] = useState("");
+  const [resolvedTenantId, setResolvedTenantId] = useState("");
   const [jobTypes, setJobTypes] = useState<string[]>([]);
   const [loadingJobTypes, setLoadingJobTypes] = useState(false);
-  const [resolvingRerunTenant, setResolvingRerunTenant] = useState(false);
+  const [resolvingRerunJob, setResolvingRerunJob] = useState(false);
   const [runningJob, setRunningJob] = useState<"generic" | "rerun" | null>(null);
 
   const formatTemplate = (jobType: string) =>
-    JSON.stringify(getJobPayloadTemplate(jobType), null, 2);
+    JSON.stringify(getPyroJobPayloadTemplate(jobType), null, 2);
 
   const normalizedRole = useMemo(
     () => String(customRole || "").trim().toUpperCase(),
@@ -54,13 +54,13 @@ const BackgroundJobsPage: React.FC = () => {
     const loadJobTypes = async () => {
       setLoadingJobTypes(true);
       try {
-        const types = await listRunnableJobTypes();
+        const types = await listRunnablePyroJobTypes();
         if (!active) return;
         setJobTypes(types);
         setSelectedJobType((current) => current || types[0] || "");
       } catch (error: any) {
         if (!active) return;
-        toast.error(error?.message || "Failed to load job types");
+        toast.error(error?.message || "Failed to load pyro job types");
       } finally {
         if (active) setLoadingJobTypes(false);
       }
@@ -87,44 +87,34 @@ const BackgroundJobsPage: React.FC = () => {
     if (!trimmedJobId) {
       setResolvedJobName("");
       setResolvedJobStatus("");
-      setResolvedRerunTenantId("");
-      setResolvingRerunTenant(false);
+      setResolvedTenantId("");
+      setResolvingRerunJob(false);
       return;
     }
 
     let cancelled = false;
     const timeoutId = window.setTimeout(async () => {
-      setResolvingRerunTenant(true);
+      setResolvingRerunJob(true);
       try {
-        const detail = await getBackgroundJobStatus(trimmedJobId);
+        const detail = await getPyroJobStatus(trimmedJobId);
         if (cancelled) return;
-        setResolvedJobName(String(detail?.job_type || ""));
+        setResolvedJobName(String(detail?.job_name || ""));
         setResolvedJobStatus(String(detail?.status || ""));
-        const resolvedTenant = String(detail?.tenant_id || "");
-        setResolvedRerunTenantId(resolvedTenant);
-        console.log("[BOB Jobs Page] auto-resolved rerun job", {
-          jobId: trimmedJobId,
-          tenantId: detail?.tenant_id,
-          jobType: detail?.job_type,
-          status: detail?.status,
-        });
-        if (!resolvedTenant) {
-          toast.error("Job found, but it has no tenant_id set");
-        }
+        const payloadTenant = detail?.payload?.tenant_id;
+        setResolvedTenantId(payloadTenant ? String(payloadTenant) : "");
       } catch (err: any) {
         if (cancelled) return;
         setResolvedJobName("");
         setResolvedJobStatus("");
-        setResolvedRerunTenantId("");
-        console.error("[BOB Jobs Page] auto-resolve rerun job failed", {
+        setResolvedTenantId("");
+        console.error("[BOB Pyro Jobs] auto-resolve failed", {
           jobId: trimmedJobId,
           message: err?.message,
-          name: err?.name,
           status: err?.status,
           data: err?.data,
         });
       } finally {
-        if (!cancelled) setResolvingRerunTenant(false);
+        if (!cancelled) setResolvingRerunJob(false);
       }
     }, 500);
 
@@ -153,20 +143,23 @@ const BackgroundJobsPage: React.FC = () => {
       return;
     }
 
-    console.log("[BOB Jobs Page] runGenericJob", {
-      selectedJobType,
-      parsedPayload,
-      selectedTenantId,
-    });
+    if (selectedTenantId.trim() && parsedPayload.tenant_id == null) {
+      parsedPayload = {
+        ...parsedPayload,
+        tenant_id: selectedTenantId.trim(),
+      };
+    }
+
     setRunningJob("generic");
     try {
-      const result = await enqueueBackgroundJob({
-        jobType: selectedJobType,
+      const result = await enqueuePyroJob({
+        jobName: selectedJobType,
         payload: parsedPayload,
         tenantId: selectedTenantId.trim() || undefined,
       });
       toast.success(
-        `${selectedJobType} queued as job #${result.id}${result.tenant_id ? ` for tenant ${result.tenant_id}` : ""}`,
+        result.message ||
+          `${selectedJobType} queued as pyro job #${result.id}`,
       );
     } catch (error: any) {
       toast.error(
@@ -181,74 +174,33 @@ const BackgroundJobsPage: React.FC = () => {
 
   const runRerunJob = async () => {
     if (!rerunJobId.trim()) {
-      toast.error("Enter a job ID to re-run");
+      toast.error("Enter a pyro job ID to re-run");
       return;
     }
-    console.log("[BOB Jobs Page] runRerunJob start", {
-      rerunJobId,
-      resolvedRerunTenantId,
-      normalizedRole,
-      hasAccess,
-    });
     setRunningJob("rerun");
     try {
-      // Pre-check so we can show a clearer message when the job
-      // doesn't exist (or doesn't belong to the current tenant).
       try {
-        console.log("[BOB Jobs Page] checking job before rerun", {
-          jobId: rerunJobId.trim(),
-        });
-        const detail = await getBackgroundJobStatus(rerunJobId.trim());
-        if (detail?.tenant_id) {
-          setResolvedRerunTenantId(String(detail.tenant_id));
-        }
-        console.log("[BOB Jobs Page] job detail check passed", {
-          jobId: rerunJobId.trim(),
-          tenantId: detail?.tenant_id,
-        });
+        const detail = await getPyroJobStatus(rerunJobId.trim());
+        setResolvedJobName(String(detail?.job_name || ""));
+        setResolvedJobStatus(String(detail?.status || ""));
+        const payloadTenant = detail?.payload?.tenant_id;
+        setResolvedTenantId(payloadTenant ? String(payloadTenant) : "");
       } catch (err: any) {
         const msg = String(err?.message || "");
-        console.error("[BOB Jobs Page] job detail check failed", {
-          jobId: rerunJobId.trim(),
-          message: err?.message,
-          name: err?.name,
-          status: err?.status,
-          data: err?.data,
-        });
         if (msg.toLowerCase().includes("job not found")) {
-          toast.error(
-            "Job not found across tenants. Confirm this is a BackgroundJob ID (not a ticket/record ID)."
-          );
+          toast.error("Pyro job not found. Confirm this is a pyro_job ID.");
           return;
         }
         throw err;
       }
 
-      const result = await rerunBackgroundJob(
-        rerunJobId.trim(),
-        resolvedRerunTenantId.trim() || undefined,
-      );
-      console.log("[BOB Jobs Page] rerun succeeded", {
-        sourceJobId: rerunJobId.trim(),
-        tenantId: resolvedRerunTenantId,
-        newJobId: result.id,
-        result,
-      });
-      toast.success(`Job requeued as new job #${result.id}`);
+      const result = await rerunPyroJob(rerunJobId.trim());
+      toast.success(`Pyro job requeued as new job #${result.id}`);
     } catch (error: any) {
-      console.error("[BOB Jobs Page] rerun failed", {
-        jobId: rerunJobId.trim(),
-        message: error?.message,
-        name: error?.name,
-        status: error?.status,
-        data: error?.data,
-        responseStatus: error?.response?.status,
-        responseData: error?.response?.data,
-      });
       toast.error(
         error?.response?.data?.error ||
           error?.message ||
-          "Failed to re-run job",
+          "Failed to re-run pyro job",
       );
     } finally {
       setRunningJob(null);
@@ -268,10 +220,10 @@ const BackgroundJobsPage: React.FC = () => {
       <DashboardLayout>
         <Card>
           <CardHeader>
-            <CardTitle>Background Jobs</CardTitle>
+            <CardTitle>Pyro Jobs</CardTitle>
           </CardHeader>
           <CardContent className="text-sm text-muted-foreground">
-            You do not have access to manually run background jobs.
+            You do not have access to manually run pyro jobs.
           </CardContent>
         </Card>
       </DashboardLayout>
@@ -282,9 +234,10 @@ const BackgroundJobsPage: React.FC = () => {
     <DashboardLayout>
       <div className="space-y-6">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Background Jobs</h1>
+          <h1 className="text-2xl font-semibold tracking-tight">Pyro Jobs</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Run any registered background job from BOB and view the queuing result.
+            Manually enqueue or re-run Brahma/Vishnu pyro jobs. Tenant ID is stored
+            in the job payload for ops context; some handlers still use fixed tenants.
           </p>
         </div>
 
@@ -293,19 +246,23 @@ const BackgroundJobsPage: React.FC = () => {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <PlayCircle className="h-5 w-5" />
-                Run Any Background Job
+                Run Any Pyro Job
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="job-type">Job Type</Label>
+                <Label htmlFor="pyro-job-type">Job Type</Label>
                 <Select
                   value={selectedJobType}
                   onValueChange={setSelectedJobType}
                   disabled={loadingJobTypes || runningJob === "generic"}
                 >
-                  <SelectTrigger id="job-type">
-                    <SelectValue placeholder={loadingJobTypes ? "Loading job types..." : "Select a job type"} />
+                  <SelectTrigger id="pyro-job-type">
+                    <SelectValue
+                      placeholder={
+                        loadingJobTypes ? "Loading job types..." : "Select a job type"
+                      }
+                    />
                   </SelectTrigger>
                   <SelectContent>
                     {jobTypes.map((jobType) => (
@@ -317,21 +274,21 @@ const BackgroundJobsPage: React.FC = () => {
                 </Select>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="job-tenant-id">Tenant ID</Label>
+                <Label htmlFor="pyro-job-tenant-id">Tenant ID</Label>
                 <Input
-                  id="job-tenant-id"
+                  id="pyro-job-tenant-id"
                   value={selectedTenantId}
                   onChange={(e) => setSelectedTenantId(e.target.value)}
                   placeholder={tenantId || "Tenant UUID"}
                   disabled={runningJob === "generic"}
                 />
                 <p className="text-xs text-muted-foreground">
-                  Defaults to your current tenant. Override this when you need to queue the job for another tenant.
+                  Defaults to your current tenant. Added to the payload as tenant_id when missing.
                 </p>
               </div>
               <div className="space-y-2">
                 <div className="flex items-center justify-between gap-2">
-                  <Label htmlFor="job-payload">Payload JSON</Label>
+                  <Label htmlFor="pyro-job-payload">Payload JSON</Label>
                   <CustomButton
                     type="button"
                     variant="outline"
@@ -343,7 +300,7 @@ const BackgroundJobsPage: React.FC = () => {
                   </CustomButton>
                 </div>
                 <Textarea
-                  id="job-payload"
+                  id="pyro-job-payload"
                   value={jobPayload}
                   onChange={(e) => setJobPayload(e.target.value)}
                   className="min-h-[220px] font-mono text-sm"
@@ -364,25 +321,25 @@ const BackgroundJobsPage: React.FC = () => {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <RefreshCw className="h-5 w-5" />
-                Re-run Existing Job
+                Re-run Existing Pyro Job
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="rerun-job-id">Job ID</Label>
+                <Label htmlFor="pyro-rerun-job-id">Job ID</Label>
                 <Input
-                  id="rerun-job-id"
+                  id="pyro-rerun-job-id"
                   value={rerunJobId}
                   onChange={(e) => setRerunJobId(e.target.value)}
-                  placeholder="7114764"
+                  placeholder="123"
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="rerun-resolved-job-name">Resolved Job</Label>
+                <Label htmlFor="pyro-resolved-job-name">Resolved Job</Label>
                 <Input
-                  id="rerun-resolved-job-name"
+                  id="pyro-resolved-job-name"
                   value={
-                    resolvingRerunTenant
+                    resolvingRerunJob
                       ? "Looking up..."
                       : resolvedJobName
                   }
@@ -391,11 +348,11 @@ const BackgroundJobsPage: React.FC = () => {
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="rerun-resolved-job-status">Status</Label>
+                <Label htmlFor="pyro-resolved-job-status">Status</Label>
                 <Input
-                  id="rerun-resolved-job-status"
+                  id="pyro-resolved-job-status"
                   value={
-                    resolvingRerunTenant
+                    resolvingRerunJob
                       ? "Looking up..."
                       : resolvedJobStatus
                   }
@@ -404,23 +361,24 @@ const BackgroundJobsPage: React.FC = () => {
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="rerun-tenant-id">Tenant ID</Label>
+                <Label htmlFor="pyro-resolved-tenant-id">Tenant ID</Label>
                 <Input
-                  id="rerun-tenant-id"
-                  value={resolvedRerunTenantId}
+                  id="pyro-resolved-tenant-id"
+                  value={resolvedTenantId}
                   readOnly
                   placeholder={
-                    resolvingRerunTenant
+                    resolvingRerunJob
                       ? "Resolving tenant..."
-                      : "Will auto-fill from job ID"
+                      : "Will auto-fill from payload.tenant_id if present"
                   }
                 />
                 <p className="text-xs text-muted-foreground">
-                  Enter a BackgroundJob ID. Job type, status, and tenant fill automatically when found.
+                  Enter a pyro_job ID. Job name, status, and payload tenant_id fill automatically when found.
                 </p>
               </div>
               <p className="text-sm text-muted-foreground">
-                This clones the original job into a new pending job without editing the source job.
+                This clones the original pyro job into a new pending row without editing
+                the source.
               </p>
               <CustomButton
                 onClick={runRerunJob}
@@ -437,4 +395,4 @@ const BackgroundJobsPage: React.FC = () => {
   );
 };
 
-export default BackgroundJobsPage;
+export default PyroJobsPage;


### PR DESCRIPTION
Give ops a dedicated BOB page to run any registered job with payload templates and re-run existing jobs with auto-resolved tenant IDs.