### PR TITLE
Make User Management fields configurable per page and tenant.

### DIFF
--- a/src/components/page-builder/add-user/AddUserView.tsx
+++ b/src/components/page-builder/add-user/AddUserView.tsx
@@ -1,4 +1,4 @@
-/** Presentational JSX for AddUserComponent. */
+/** Presentational JSX for AddUserComponent — columns/fields from tenant config. */
 
 import React from 'react';
 import { Input } from '@/components/ui/input';
@@ -9,30 +9,14 @@ import { format } from "date-fns";
 import { Trash2, UserPlus, Pencil, Check, X, Search, Download } from 'lucide-react';
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import type { AddUserModel } from './useAddUser';
-import type { User, Role } from './types';
-import { formatResolveRateGoal, isCseRole } from './utils';
-
-function SupportDailyDualDisplay({
-  selfTrial,
-  other,
-}: {
-  selfTrial?: string | number;
-  other?: string | number;
-}) {
-  const st = selfTrial === undefined || selfTrial === '—' ? null : selfTrial;
-  const ot = other === undefined || other === '—' ? null : other;
-  if (st === null && ot === null) return <>—</>;
-  return (
-    <div className="text-sm leading-snug space-y-0.5">
-      <div>
-        <span className="text-gray-500">ST:</span> {st ?? '—'}
-      </div>
-      <div>
-        <span className="text-gray-500">Other:</span> {ot ?? '—'}
-      </div>
-    </div>
-  );
-}
+import type { User } from './types';
+import { useUserManagementConfig } from './useUserManagementConfig';
+import {
+  getColumnLabel,
+  isBoundCustomField,
+  type UserManagementColumn,
+  type UserManagementCustomField,
+} from './userManagementConfig';
 
 function SupportDailyDualInputs({
   selfTrial,
@@ -81,20 +65,40 @@ function SupportDailyDualInputs({
   );
 }
 
+function boundCustomFieldDisplay(user: User, fieldKey: string): string {
+  switch (fieldKey) {
+    case 'manager_email':
+      return user.managerEmail && user.managerEmail !== '—' ? user.managerEmail : '—';
+    case 'lead_group':
+      return user.leadGroup && user.leadGroup !== '—' ? String(user.leadGroup) : '—';
+    case 'daily_target':
+      return user.dailyTarget != null && user.dailyTarget !== '—'
+        ? String(user.dailyTarget)
+        : '—';
+    case 'daily_limit':
+      return user.dailyLimit != null && user.dailyLimit !== '—'
+        ? String(user.dailyLimit)
+        : '—';
+    case 'resolve_rate_goal':
+      return user.supportResolveRateGoal != null && user.supportResolveRateGoal !== '—'
+        ? String(user.supportResolveRateGoal)
+        : '—';
+    case 'support_daily_limits': {
+      const st = user.supportDailyLimitSelfTrial;
+      const other = user.supportDailyLimitOther;
+      if ((st == null || st === '—') && (other == null || other === '—')) return '—';
+      return `ST: ${st ?? '—'} / Other: ${other ?? '—'}`;
+    }
+    default:
+      return '—';
+  }
+}
+
 export function AddUserView(props: AddUserModel) {
   const {
     config,
-    user,
-    session,
-    navigate,
-    tenantSlug,
-    tenantId,
     roles,
-    setRoles,
     users,
-    setUsers,
-    myMembershipId,
-    setMyMembershipId,
     selectedRoleId,
     setSelectedRoleId,
     newRoleName,
@@ -104,43 +108,16 @@ export function AddUserView(props: AddUserModel) {
     formData,
     setFormData,
     isLoading,
-    setIsLoading,
     showRoleFields,
     setShowRoleFields,
-    coreSettingsMap,
-    setCoreSettingsMap,
-    availableLeadGroups,
-    setAvailableLeadGroups,
     isCreatingUser,
-    setIsCreatingUser,
-    selectedQueueType,
-    setSelectedQueueType,
-    queueTypes,
-    setQueueTypes,
     editingRowKey,
-    setEditingRowKey,
     editingRow,
     setEditingRow,
     isUpdatingRow,
-    setIsUpdatingRow,
     usersPdfLoading,
-    setUsersPdfLoading,
-    managerSearch,
-    setManagerSearch,
-    showManagerDropdown,
-    setShowManagerDropdown,
-    editManagerSearch,
-    setEditManagerSearch,
-    showEditManagerDropdown,
-    setShowEditManagerDropdown,
     userSearchTerm,
     setUserSearchTerm,
-    managerDropdownRef,
-    editManagerDropdownRef,
-    closeManagerDropdowns,
-    fetchUsers,
-    fetchCoreSettings,
-    usersWithSettings,
     filteredUsersWithSettings,
     handleDownloadUsersPdf,
     handleChange,
@@ -151,303 +128,723 @@ export function AddUserView(props: AddUserModel) {
     handleEditUser,
     handleCancelRowEdit,
     handleSaveRowEdit,
+    managerSearch,
+    setManagerSearch,
+    showManagerDropdown,
+    setShowManagerDropdown,
+    editManagerSearch,
+    setEditManagerSearch,
+    showEditManagerDropdown,
+    setShowEditManagerDropdown,
+    managerDropdownRef,
+    editManagerDropdownRef,
+    selectedQueueType,
+    setSelectedQueueType,
+    queueTypes,
+    availableLeadGroups,
   } = props;
 
-  return (
-    <Card className="w-full border border-gray-200 shadow-sm rounded-2xl">
-      <CardHeader className="pb-3">
-        <h5 className="flex items-center gap-2 text-2xl font-semibold leading-none">
-          <UserPlus className="h-5 w-5 text-gray-700" />
-          User Management
-        </h5>
-      </CardHeader>
-      <CardContent className="space-y-8">
-        {/* Add User Form */}
-        <div className="space-y-5 border border-gray-200 rounded-xl p-5 md:p-6">
-          <h5 className="text-2xl font-semibold leading-none">Add New User</h5>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-            <div className="space-y-2">
-              <Label htmlFor="name">Full Name</Label>
-              <Input
-                id="name"
-                name="name"
-                placeholder="Enter full name"
-                value={formData.name}
-                onChange={handleChange}
-                className="h-11"
-              />
-            </div>
+  const { schema, showField } = useUserManagementConfig(config);
+  const showCustomForm = (key: string) =>
+    schema.customFields.some((f) => f.key === key && f.showInForm);
 
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                name="email"
-                placeholder="user@example.com"
-                value={formData.email}
-                onChange={handleChange}
-                className="h-11"
-              />
-            </div>
-          </div>
+  const customFormFields = schema.customFields.filter(
+    (f) => f.showInForm && !isBoundCustomField(f.key)
+  );
+  const customTableFields = schema.customFields.filter((f) => f.showInTable);
+  const showManagerForm = showCustomForm('manager_email');
+  const showQueueTypeForm = showCustomForm('queue_type');
+  const showLeadGroupForm = showCustomForm('lead_group');
+  const showDailyTargetForm = showCustomForm('daily_target');
+  const showDailyLimitForm = showCustomForm('daily_limit');
+  const showResolveGoalForm = showCustomForm('resolve_rate_goal');
+  const showSupportLimitsForm = showCustomForm('support_daily_limits');
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
-            <div className="space-y-2">
-              <Label htmlFor="department">Department (optional)</Label>
-              <Input
-                id="department"
-                name="department"
-                placeholder="e.g, engineering, sales"
-                value={formData.department}
-                onChange={handleChange}
-                className="h-11"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="role">Select Role</Label>
-              <select
-                id="role"
-                className="h-11 w-full border rounded-md px-3 text-sm bg-white"
-                value={selectedRoleId}
-                onChange={(e) => setSelectedRoleId(e.target.value)}
+  // If queue type is on the form, lead vs ticket fields follow it.
+  // Otherwise show whichever bound fields are enabled.
+  const showLeadTargets =
+    (showDailyTargetForm || showDailyLimitForm) &&
+    (!showQueueTypeForm || selectedQueueType !== 'ticket');
+  const showTicketTargets =
+    (showResolveGoalForm || showSupportLimitsForm) &&
+    (!showQueueTypeForm || selectedQueueType === 'ticket');
+  const showBoundFormRow =
+    showManagerForm ||
+    showLeadGroupForm ||
+    showQueueTypeForm ||
+    showLeadTargets ||
+    showTicketTargets;
+  const renderManagerEditCell = (user: User) => (
+    <div className="relative" ref={editManagerDropdownRef}>
+      <div className="flex gap-1">
+        <div className="relative flex-1">
+          <Input
+            className="h-9 pr-8 text-sm"
+            placeholder="Search manager..."
+            value={showEditManagerDropdown ? editManagerSearch : editingRow?.managerEmail ?? ''}
+            onChange={(e) => {
+              setEditManagerSearch(e.target.value);
+              setShowEditManagerDropdown(true);
+            }}
+            onFocus={() => {
+              setEditManagerSearch('');
+              setShowEditManagerDropdown(true);
+            }}
+            autoComplete="off"
+          />
+          <Search className="absolute right-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400 pointer-events-none" />
+        </div>
+        {editingRow?.managerEmail && (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="h-9 w-9 shrink-0 border-gray-200 text-gray-500 hover:text-gray-700"
+            onClick={() => {
+              setEditingRow((prev) => (prev ? { ...prev, managerEmail: '' } : prev));
+              setEditManagerSearch('');
+              setShowEditManagerDropdown(false);
+            }}
+            title="Clear manager"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+      {showEditManagerDropdown && (
+        <div className="absolute z-50 mt-1 w-64 max-h-40 overflow-y-auto rounded-md border border-gray-200 bg-white shadow-lg">
+          {users
+            .filter((u) => {
+              if (u.email === user.email) return false;
+              if (!editManagerSearch.trim()) return true;
+              const q = editManagerSearch.toLowerCase();
+              return (
+                (u.name || '').toLowerCase().includes(q) ||
+                (u.email || '').toLowerCase().includes(q)
+              );
+            })
+            .map((u) => (
+              <button
+                key={u.uid}
+                type="button"
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-gray-100"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  setEditingRow((prev) =>
+                    prev ? { ...prev, managerEmail: u.email } : prev
+                  );
+                  setEditManagerSearch('');
+                  setShowEditManagerDropdown(false);
+                }}
               >
-                <option value="">--select role--</option>
+                <span className="font-medium truncate">{u.name}</span>
+                <span className="text-gray-400 truncate">{u.email}</span>
+              </button>
+            ))}
+        </div>
+      )}
+    </div>
+  );
+
+  const renderCustomTableCell = (
+    field: UserManagementCustomField,
+    user: User,
+    isEditing: boolean
+  ) => {
+    if (field.key === 'manager_email') {
+      return (
+        <TableCell key={`${user.uid}-cf-manager_email`}>
+          {isEditing && editingRow ? renderManagerEditCell(user) : boundCustomFieldDisplay(user, field.key)}
+        </TableCell>
+      );
+    }
+
+    if (isBoundCustomField(field.key)) {
+      return (
+        <TableCell key={`${user.uid}-cf-${field.key}`}>
+          {boundCustomFieldDisplay(user, field.key)}
+        </TableCell>
+      );
+    }
+
+    const valueKey = field.key.toLowerCase();
+    const displayValue =
+      user.customFields?.[field.key] ?? user.customFields?.[valueKey] ?? '—';
+
+    return (
+      <TableCell key={`${user.uid}-cf-${field.key}`}>
+        {isEditing && editingRow ? (
+          field.type === 'boolean' ? (
+            <select
+              className="h-9 w-full border rounded-md px-2 text-sm bg-white"
+              value={editingRow.customFields[field.key] ?? ''}
+              onChange={(e) =>
+                setEditingRow((prev) =>
+                  prev
+                    ? {
+                        ...prev,
+                        customFields: {
+                          ...prev.customFields,
+                          [field.key]: e.target.value,
+                        },
+                      }
+                    : prev
+                )
+              }
+            >
+              <option value="">—</option>
+              <option value="true">Yes</option>
+              <option value="false">No</option>
+            </select>
+          ) : (
+            <Input
+              className="h-9"
+              type={field.type === 'number' ? 'number' : 'text'}
+              value={editingRow.customFields[field.key] ?? ''}
+              onChange={(e) =>
+                setEditingRow((prev) =>
+                  prev
+                    ? {
+                        ...prev,
+                        customFields: {
+                          ...prev.customFields,
+                          [field.key]: e.target.value,
+                        },
+                      }
+                    : prev
+                )
+              }
+            />
+          )
+        ) : displayValue === 'true' ? (
+          'Yes'
+        ) : displayValue === 'false' ? (
+          'No'
+        ) : (
+          displayValue
+        )}
+      </TableCell>
+    );
+  };
+
+  const renderColumnCell = (column: UserManagementColumn, user: User) => {
+    const isEditing = editingRowKey === getRowKey(user) && !!editingRow;
+    const cellKey = `${getRowKey(user)}-${column}`;
+
+    switch (column) {
+      case 'name':
+        return (
+          <TableCell key={cellKey} className="text-body-medium">
+            {user.name}
+          </TableCell>
+        );
+      case 'email':
+        return <TableCell key={cellKey}>{user.email}</TableCell>;
+      case 'department':
+        return (
+          <TableCell key={cellKey}>
+            {isEditing && editingRow ? (
+              <Input
+                className="h-9"
+                value={editingRow.department}
+                onChange={(e) =>
+                  setEditingRow((prev) =>
+                    prev ? { ...prev, department: e.target.value } : prev
+                  )
+                }
+                placeholder="Department"
+              />
+            ) : (
+              user.department || '—'
+            )}
+          </TableCell>
+        );
+      case 'role':
+        return (
+          <TableCell key={cellKey}>
+            {isEditing && editingRow ? (
+              <select
+                className="h-9 w-full border rounded-md px-2 text-sm bg-white"
+                value={editingRow.roleId}
+                onChange={(e) =>
+                  setEditingRow((prev) =>
+                    prev ? { ...prev, roleId: e.target.value } : prev
+                  )
+                }
+              >
                 {roles.map((role) => (
                   <option key={role.id} value={role.id}>
                     {role.name}
                   </option>
                 ))}
               </select>
+            ) : (
+              user.role?.name || '—'
+            )}
+          </TableCell>
+        );
+      case 'created_at':
+        return (
+          <TableCell key={cellKey}>
+            {format(
+              new Date(new Date(user.created_at).getTime() + 5.5 * 60 * 60 * 1000),
+              'MMM d, yyyy h:mm a'
+            )}
+          </TableCell>
+        );
+      case 'actions':
+        return (
+          <TableCell key={cellKey} className="text-right">
+            <div className="inline-flex items-center justify-end gap-2">
+              {editingRowKey === getRowKey(user) ? (
+                <>
+                  <Button
+                    type="button"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={handleSaveRowEdit}
+                    disabled={isUpdatingRow}
+                  >
+                    <Check className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={handleCancelRowEdit}
+                    disabled={isUpdatingRow}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={() => handleEditUser(user)}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8 text-destructive"
+                    onClick={() => handleDeleteUser(user.email, user.uid)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </>
+              )}
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="queueType">Queue Type</Label>
-              <select
-                id="queueType"
-                className="h-11 w-full border rounded-md px-3 text-sm bg-white"
-                value={selectedQueueType}
-                onChange={(e) => {
-                  const nextType = e.target.value === 'ticket' ? 'ticket' : 'lead';
-                  setSelectedQueueType(nextType);
-                  if (nextType === 'ticket') {
-                    setFormData((prev) => ({ ...prev, dailyTarget: '' }));
-                  } else {
-                    setFormData((prev) => ({
-                      ...prev,
-                      supportResolveRateGoal: '',
-                      supportDailyLimitSelfTrial: '',
-                      supportDailyLimitOther: '',
-                    }));
-                  }
-                }}
-              >
-                {(queueTypes.length ? queueTypes : ['lead', 'ticket']).map((qt) => (
-                  <option key={qt} value={qt === 'ticket' ? 'ticket' : 'lead'}>
-                    {qt === 'ticket' ? 'Support Tickets' : 'Leads'}
-                  </option>
-                ))}
-              </select>
-            </div>
+          </TableCell>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Card className="w-full">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+        <div className="flex items-center gap-2">
+          <UserPlus className="h-5 w-5" />
+          <h3 className="text-lg font-semibold">User Management</h3>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              className="h-9 w-56 pl-8"
+              placeholder="Search users..."
+              value={userSearchTerm}
+              onChange={(e) => setUserSearchTerm(e.target.value)}
+            />
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-9"
+            onClick={handleDownloadUsersPdf}
+            disabled={usersPdfLoading || filteredUsersWithSettings.length === 0}
+          >
+            <Download className="h-4 w-4 mr-1" />
+            {usersPdfLoading ? '...' : 'PDF'}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="space-y-5 rounded-lg border p-5">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+            {showField('name') && (
+              <div className="space-y-2">
+                <Label htmlFor="name">Full Name</Label>
+                <Input
+                  id="name"
+                  name="name"
+                  className="h-11"
+                  value={formData.name}
+                  onChange={handleChange}
+                  placeholder="Full name"
+                />
+              </div>
+            )}
+            {showField('email') && (
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  name="email"
+                  type="email"
+                  className="h-11"
+                  value={formData.email}
+                  onChange={handleChange}
+                  placeholder="Email"
+                />
+              </div>
+            )}
+            {showField('department') && (
+              <div className="space-y-2">
+                <Label htmlFor="department">Department</Label>
+                <Input
+                  id="department"
+                  name="department"
+                  className="h-11"
+                  value={formData.department}
+                  onChange={handleChange}
+                  placeholder="Department"
+                />
+              </div>
+            )}
+            {showField('role') && (
+              <div className="space-y-2">
+                <Label htmlFor="role">Role</Label>
+                <select
+                  id="role"
+                  className="h-11 w-full border rounded-md px-3 text-sm bg-white"
+                  value={selectedRoleId}
+                  onChange={(e) => setSelectedRoleId(e.target.value)}
+                >
+                  <option value="">--select role--</option>
+                  {roles.map((role) => (
+                    <option key={role.id} value={role.id}>
+                      {role.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
-            <div className="space-y-2">
-              <Label htmlFor="managerEmail">Manager Email (optional)</Label>
-              <div className="relative" ref={managerDropdownRef}>
-                <div className="flex gap-1">
-                  <div className="relative flex-1">
-                    <Input
-                      id="managerEmail"
-                      placeholder="Search by name or email..."
-                      value={showManagerDropdown ? managerSearch : formData.managerEmail}
-                      onChange={(e) => {
-                        setManagerSearch(e.target.value);
-                        setShowManagerDropdown(true);
-                      }}
-                      onFocus={() => {
-                        setManagerSearch('');
-                        setShowManagerDropdown(true);
-                      }}
-                      className="h-11 pr-9"
-                      autoComplete="off"
-                    />
-                    <Search className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
-                  </div>
-                  {formData.managerEmail && (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      className="h-11 w-11 shrink-0 border-gray-300 text-gray-500 hover:text-gray-700"
-                      onClick={() => {
-                        setFormData((prev) => ({ ...prev, managerEmail: '' }));
-                        setManagerSearch('');
-                        setShowManagerDropdown(false);
-                      }}
-                      title="Clear manager"
-                    >
-                      <X className="h-4 w-4" />
-                    </Button>
-                  )}
+          {(showBoundFormRow || customFormFields.length > 0) && (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+              {showQueueTypeForm && (
+                <div className="space-y-2">
+                  <Label htmlFor="queueType">Queue Type</Label>
+                  <select
+                    id="queueType"
+                    className="h-11 w-full border rounded-md px-3 text-sm bg-white"
+                    value={selectedQueueType}
+                    onChange={(e) => {
+                      const nextType = e.target.value === 'ticket' ? 'ticket' : 'lead';
+                      setSelectedQueueType(nextType);
+                      if (nextType === 'ticket') {
+                        setFormData((prev) => ({ ...prev, dailyTarget: '' }));
+                      } else {
+                        setFormData((prev) => ({
+                          ...prev,
+                          supportResolveRateGoal: '',
+                          supportDailyLimitSelfTrial: '',
+                          supportDailyLimitOther: '',
+                        }));
+                      }
+                    }}
+                  >
+                    {(queueTypes.length ? queueTypes : ['lead', 'ticket']).map((qt) => (
+                      <option key={qt} value={qt === 'ticket' ? 'ticket' : 'lead'}>
+                        {qt === 'ticket' ? 'Support Tickets' : 'Leads'}
+                      </option>
+                    ))}
+                  </select>
                 </div>
-                {showManagerDropdown && (
-                  <div className="absolute z-50 mt-1 w-full max-h-48 overflow-y-auto rounded-md border border-gray-200 bg-white shadow-lg">
-                    {users
-                      .filter((u) => {
-                        if (!managerSearch.trim()) return true;
-                        const q = managerSearch.toLowerCase();
-                        return (u.name || '').toLowerCase().includes(q) || (u.email || '').toLowerCase().includes(q);
-                      })
-                      .map((u) => (
-                        <button
-                          key={u.uid}
+              )}
+
+              {showManagerForm && (
+                <div className="space-y-2">
+                  <Label htmlFor="managerEmail">Manager Email (optional)</Label>
+                  <div className="relative" ref={managerDropdownRef}>
+                    <div className="flex gap-1">
+                      <div className="relative flex-1">
+                        <Input
+                          id="managerEmail"
+                          placeholder="Search by name or email..."
+                          value={showManagerDropdown ? managerSearch : formData.managerEmail}
+                          onChange={(e) => {
+                            setManagerSearch(e.target.value);
+                            setShowManagerDropdown(true);
+                          }}
+                          onFocus={() => {
+                            setManagerSearch('');
+                            setShowManagerDropdown(true);
+                          }}
+                          className="h-11 pr-9"
+                          autoComplete="off"
+                        />
+                        <Search className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
+                      </div>
+                      {formData.managerEmail && (
+                        <Button
                           type="button"
-                          className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-gray-100"
-                          onMouseDown={(e) => e.preventDefault()}
+                          variant="outline"
+                          size="icon"
+                          className="h-11 w-11 shrink-0 border-gray-300 text-gray-500 hover:text-gray-700"
                           onClick={() => {
-                            setFormData((prev) => ({ ...prev, managerEmail: u.email }));
+                            setFormData((prev) => ({ ...prev, managerEmail: '' }));
                             setManagerSearch('');
                             setShowManagerDropdown(false);
                           }}
+                          title="Clear manager"
                         >
-                          <span className="font-medium truncate">{u.name}</span>
-                          <span className="text-gray-500 truncate text-xs">{u.email}</span>
-                        </button>
-                      ))}
-                    {users.filter((u) => {
-                      if (!managerSearch.trim()) return true;
-                      const q = managerSearch.toLowerCase();
-                      return (u.name || '').toLowerCase().includes(q) || (u.email || '').toLowerCase().includes(q);
-                    }).length === 0 && (
-                      <div className="px-3 py-2 text-sm text-gray-400">No users found</div>
+                          <X className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                    {showManagerDropdown && (
+                      <div className="absolute z-50 mt-1 w-full max-h-48 overflow-y-auto rounded-md border border-gray-200 bg-white shadow-lg">
+                        {users
+                          .filter((u) => {
+                            if (!managerSearch.trim()) return true;
+                            const q = managerSearch.toLowerCase();
+                            return (
+                              (u.name || '').toLowerCase().includes(q) ||
+                              (u.email || '').toLowerCase().includes(q)
+                            );
+                          })
+                          .map((u) => (
+                            <button
+                              key={u.uid}
+                              type="button"
+                              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-gray-100"
+                              onMouseDown={(e) => e.preventDefault()}
+                              onClick={() => {
+                                setFormData((prev) => ({ ...prev, managerEmail: u.email }));
+                                setManagerSearch('');
+                                setShowManagerDropdown(false);
+                              }}
+                            >
+                              <span className="font-medium truncate">{u.name}</span>
+                              <span className="text-gray-500 truncate text-xs">{u.email}</span>
+                            </button>
+                          ))}
+                        {users.filter((u) => {
+                          if (!managerSearch.trim()) return true;
+                          const q = managerSearch.toLowerCase();
+                          return (
+                            (u.name || '').toLowerCase().includes(q) ||
+                            (u.email || '').toLowerCase().includes(q)
+                          );
+                        }).length === 0 && (
+                          <div className="px-3 py-2 text-sm text-gray-400">No users found</div>
+                        )}
+                      </div>
                     )}
                   </div>
-                )}
-              </div>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="leadGroup">Lead Group</Label>
-              <select
-                id="leadGroup"
-                className="h-11 w-full border rounded-md px-3 text-sm bg-white"
-                value={formData.leadGroup}
-                onChange={(e) => {
-                  const selectedName = e.target.value;
-                  const selectedGroup = availableLeadGroups.find((group) => group.name === selectedName);
-                  setFormData((prev) => ({ ...prev, leadGroup: selectedName }));
-                  if (selectedGroup?.queue_type === 'ticket') {
-                    setSelectedQueueType('ticket');
-                    setFormData((prev) => ({ ...prev, dailyTarget: '' }));
-                  } else if (selectedGroup?.queue_type === 'lead') {
-                    setSelectedQueueType('lead');
-                    setFormData((prev) => ({
-                      ...prev,
-                      supportResolveRateGoal: '',
-                      supportDailyLimitSelfTrial: '',
-                      supportDailyLimitOther: '',
-                    }));
-                  }
-                }}
-              >
-                <option value="">Select Group</option>
-                {availableLeadGroups
-                  .map((group) => (
-                    <option key={group.name} value={group.name}>
-                      {group.name}
-                    </option>
-                  ))}
-              </select>
-            </div>
-            {selectedQueueType === 'ticket' ? (
-              <>
-                <div className="space-y-2">
-                  <Label htmlFor="resolveRateGoal">Resolve Goal %</Label>
-                  <Input
-                    id="resolveRateGoal"
-                    type="number"
-                    min="0"
-                    max="100"
-                    step="1"
-                    value={formData.supportResolveRateGoal}
-                    onChange={(e) =>
-                      setFormData((prev) => ({ ...prev, supportResolveRateGoal: e.target.value }))
-                    }
-                    placeholder="80"
-                  />
                 </div>
+              )}
+
+              {showLeadGroupForm && (
                 <div className="space-y-2">
-                  <Label>Daily Limit</Label>
-                  <div className="rounded-md border border-gray-200 p-3">
-                    <SupportDailyDualInputs
-                      selfTrial={formData.supportDailyLimitSelfTrial}
-                      other={formData.supportDailyLimitOther}
-                      onSelfTrialChange={(value) =>
-                        setFormData((prev) => ({ ...prev, supportDailyLimitSelfTrial: value }))
+                  <Label htmlFor="leadGroup">Lead Group</Label>
+                  <select
+                    id="leadGroup"
+                    className="h-11 w-full border rounded-md px-3 text-sm bg-white"
+                    value={formData.leadGroup}
+                    onChange={(e) => {
+                      const selectedName = e.target.value;
+                      const selectedGroup = availableLeadGroups.find(
+                        (group) => group.name === selectedName
+                      );
+                      setFormData((prev) => ({ ...prev, leadGroup: selectedName }));
+                      if (selectedGroup?.queue_type === 'ticket') {
+                        setSelectedQueueType('ticket');
+                        setFormData((prev) => ({ ...prev, dailyTarget: '' }));
+                      } else if (selectedGroup?.queue_type === 'lead') {
+                        setSelectedQueueType('lead');
+                        setFormData((prev) => ({
+                          ...prev,
+                          supportResolveRateGoal: '',
+                          supportDailyLimitSelfTrial: '',
+                          supportDailyLimitOther: '',
+                        }));
                       }
-                      onOtherChange={(value) =>
-                        setFormData((prev) => ({ ...prev, supportDailyLimitOther: value }))
+                    }}
+                  >
+                    <option value="">Select Group</option>
+                    {availableLeadGroups.map((group) => (
+                      <option key={group.name} value={group.name}>
+                        {group.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+
+              {showTicketTargets ? (
+                <>
+                  {showResolveGoalForm && (
+                    <div className="space-y-2">
+                      <Label htmlFor="resolveRateGoal">Resolve Goal %</Label>
+                      <Input
+                        id="resolveRateGoal"
+                        type="number"
+                        min="0"
+                        max="100"
+                        step="1"
+                        className="h-11"
+                        value={formData.supportResolveRateGoal}
+                        onChange={(e) =>
+                          setFormData((prev) => ({
+                            ...prev,
+                            supportResolveRateGoal: e.target.value,
+                          }))
+                        }
+                        placeholder="80"
+                      />
+                    </div>
+                  )}
+                  {showSupportLimitsForm && (
+                    <div className="space-y-2">
+                      <Label>Support Daily Limits</Label>
+                      <div className="rounded-md border border-gray-200 p-3">
+                        <SupportDailyDualInputs
+                          selfTrial={formData.supportDailyLimitSelfTrial}
+                          other={formData.supportDailyLimitOther}
+                          onSelfTrialChange={(value) =>
+                            setFormData((prev) => ({
+                              ...prev,
+                              supportDailyLimitSelfTrial: value,
+                            }))
+                          }
+                          onOtherChange={(value) =>
+                            setFormData((prev) => ({
+                              ...prev,
+                              supportDailyLimitOther: value,
+                            }))
+                          }
+                          inputClassName="h-10"
+                        />
+                      </div>
+                    </div>
+                  )}
+                </>
+              ) : null}
+
+              {showLeadTargets ? (
+                <>
+                  {showDailyTargetForm && (
+                    <div className="space-y-2">
+                      <Label htmlFor="dailyTarget">Daily Target</Label>
+                      <Input
+                        id="dailyTarget"
+                        type="number"
+                        min="0"
+                        step="1"
+                        className="h-11"
+                        value={formData.dailyTarget}
+                        onChange={(e) =>
+                          setFormData((prev) => ({ ...prev, dailyTarget: e.target.value }))
+                        }
+                        placeholder="Enter daily target"
+                      />
+                    </div>
+                  )}
+                  {showDailyLimitForm && (
+                    <div className="space-y-2">
+                      <Label htmlFor="dailyLimit">Daily Limit</Label>
+                      <Input
+                        id="dailyLimit"
+                        type="number"
+                        min="0"
+                        step="1"
+                        className="h-11"
+                        value={formData.dailyLimit}
+                        onChange={(e) =>
+                          setFormData((prev) => ({ ...prev, dailyLimit: e.target.value }))
+                        }
+                        placeholder="Enter daily limit"
+                      />
+                    </div>
+                  )}
+                </>
+              ) : null}
+
+              {customFormFields.map((field) => (
+                <div key={field.key} className="space-y-2">
+                  <Label htmlFor={`custom-${field.key}`}>{field.label}</Label>
+                  {field.type === 'boolean' ? (
+                    <select
+                      id={`custom-${field.key}`}
+                      className="h-11 w-full border rounded-md px-3 text-sm bg-white"
+                      value={formData.customFields[field.key] ?? ''}
+                      onChange={(e) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          customFields: { ...prev.customFields, [field.key]: e.target.value },
+                        }))
                       }
-                      inputClassName="h-10"
+                    >
+                      <option value="">—</option>
+                      <option value="true">Yes</option>
+                      <option value="false">No</option>
+                    </select>
+                  ) : (
+                    <Input
+                      id={`custom-${field.key}`}
+                      type={field.type === 'number' ? 'number' : 'text'}
+                      className="h-11"
+                      value={formData.customFields[field.key] ?? ''}
+                      onChange={(e) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          customFields: { ...prev.customFields, [field.key]: e.target.value },
+                        }))
+                      }
+                      placeholder={field.label}
                     />
-                  </div>
+                  )}
                 </div>
-              </>
-            ) : (
-              <>
-                <div className="space-y-2">
-                  <Label htmlFor="dailyTarget">Daily Target</Label>
-                  <Input
-                    id="dailyTarget"
-                    type="number"
-                    min="0"
-                    step="1"
-                    className="h-11"
-                    value={formData.dailyTarget}
-                    onChange={(e) => setFormData((prev) => ({ ...prev, dailyTarget: e.target.value }))}
-                    placeholder="Enter daily target"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="dailyLimit">Daily Limit</Label>
-                  <Input
-                    id="dailyLimit"
-                    type="number"
-                    min="0"
-                    step="1"
-                    className="h-11"
-                    value={formData.dailyLimit}
-                    onChange={(e) => setFormData((prev) => ({ ...prev, dailyLimit: e.target.value }))}
-                    placeholder="Enter daily limit"
-                  />
-                </div>
-              </>
-            )}
-          </div>
-          {/* Action Buttons */}
+              ))}
+            </div>
+          )}
           <div className="flex gap-2">
-            <Button 
-              className="flex-1 h-11 bg-black text-white hover:bg-black border-none rounded-md disabled:bg-gray-400 disabled:text-white disabled:opacity-100" 
+            <Button
+              className="flex-1 h-11 bg-black text-white hover:bg-black border-none rounded-md disabled:bg-gray-400 disabled:text-white disabled:opacity-100"
               onClick={handleAddUser}
-              disabled={!selectedRoleId || isCreatingUser}
+              disabled={(showField('role') && !selectedRoleId) || isCreatingUser}
             >
               {isCreatingUser ? 'Adding...' : 'Add User'}
             </Button>
-            <Button 
-              type="button" 
-              variant="outline" 
-              className="flex-1 h-11 text-black border-gray-300 hover:bg-white hover:text-black rounded-md"
-              onClick={() => setShowRoleFields(!showRoleFields)}
-              disabled={!!selectedRoleId}
-            >
-              Add New Role
-            </Button>
+            {showField('role') && (
+              <Button
+                type="button"
+                variant="outline"
+                className="flex-1 h-11 text-black border-gray-300 hover:bg-white hover:text-black rounded-md"
+                onClick={() => setShowRoleFields(!showRoleFields)}
+                disabled={!!selectedRoleId}
+              >
+                Add New Role
+              </Button>
+            )}
           </div>
 
-          {/* Collapsible Role Creation Fields */}
-          {showRoleFields && (
+          {showField('role') && showRoleFields && (
             <div className="space-y-4 p-4 bg-muted/30 rounded-lg border">
               <h5>Create New Role</h5>
-              
               <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                 <div className="space-y-2">
                   <Label htmlFor="newRoleKey">Role Key</Label>
@@ -468,322 +865,50 @@ export function AddUserView(props: AddUserModel) {
                   />
                 </div>
               </div>
-              
-              <div className="flex gap-2">
-                <Button type="button" onClick={handleAddRole} className="flex-1 bg-black text-white border-none hover:bg-black">
-                  Create Role
-                </Button>
-                <Button 
-                  type="button" 
-                  variant="outline" 
-                  onClick={() => {
-                    setShowRoleFields(false);
-                    setNewRoleName('');
-                    setNewRoleKey('');
-                  }}
-                  className="flex-1 text-black border-gray-300 hover:bg-white hover:text-black"
-                >
-                  Cancel
-                </Button>
-              </div>
+              <Button type="button" onClick={handleAddRole}>
+                Create Role
+              </Button>
             </div>
           )}
         </div>
 
-        {/* Users List */}
-        <div className="space-y-4">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <h5 className="text-2xl font-semibold">Users</h5>
-            <div className="flex w-full flex-col gap-3 sm:max-w-md sm:flex-row sm:items-center">
-              <div className="relative w-full sm:flex-1">
-                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-                <Input
-                  value={userSearchTerm}
-                  onChange={(e) => setUserSearchTerm(e.target.value)}
-                  placeholder="Search by name, email or role..."
-                  className="h-11 pl-9"
-                />
-              </div>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => void handleDownloadUsersPdf()}
-                disabled={isLoading || usersPdfLoading || filteredUsersWithSettings.length === 0}
-                className="h-11 shrink-0 border-black text-black hover:bg-black hover:text-white"
-              >
-                <Download className="mr-2 h-4 w-4" />
-                {usersPdfLoading ? 'Generating…' : 'Download PDF'}
-              </Button>
-            </div>
-          </div>
+        <div className="space-y-3">
           {isLoading ? (
-            <div className="flex justify-center items-center h-32">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-foreground"></div>
-            </div>
-          ) : users.length === 0 ? (
-            <div className="text-center text-muted-foreground py-8">
-              No users found
-            </div>
-          ) : filteredUsersWithSettings.length === 0 ? (
-            <div className="text-center text-muted-foreground py-8">
-              No users match your search
-            </div>
+            <p className="text-sm text-muted-foreground">Loading users...</p>
           ) : (
-            <div className="overflow-x-auto border border-gray-200 rounded-xl bg-white">
+            <div className="rounded-md border overflow-x-auto">
               <Table>
                 <TableHeader>
-                  <TableRow className="bg-black hover:!bg-black text-white hover:text-white">
-                    <TableHead className="text-white font-medium">Name</TableHead>
-                    <TableHead className="text-white font-medium">Email</TableHead>
-                    <TableHead className="text-white font-medium">Role</TableHead>
-                    <TableHead className="text-white font-medium">Group</TableHead>
-                    <TableHead className="text-white font-medium">Target</TableHead>
-                    <TableHead className="text-white font-medium">Daily Limit</TableHead>
-                    <TableHead className="text-white font-medium">Manager Email</TableHead>
-                    <TableHead className="text-white font-medium">Created at</TableHead>
-                    <TableHead className="text-white font-medium text-right"></TableHead>
+                  <TableRow className="bg-black hover:bg-black">
+                    {schema.columns
+                      .filter((column) => column !== 'actions')
+                      .map((column) => (
+                        <TableHead key={column} className="text-white font-medium">
+                          {getColumnLabel(column)}
+                        </TableHead>
+                      ))}
+                    {customTableFields.map((field) => (
+                      <TableHead key={`cf-${field.key}`} className="text-white font-medium">
+                        {field.label}
+                      </TableHead>
+                    ))}
+                    {schema.columns.includes('actions') && (
+                      <TableHead className="text-white font-medium text-right" />
+                    )}
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {filteredUsersWithSettings.map((user, index) => {
-                    const rowIsCse =
-                      editingRowKey === getRowKey(user) && editingRow
-                        ? isCseRole(roles.find((r) => r.id === editingRow.roleId))
-                        : isCseRole(user.role);
+                    const isEditing = editingRowKey === getRowKey(user) && !!editingRow;
                     return (
                       <TableRow key={`${user.uid}-${index}`}>
-                        <TableCell className="text-body-medium">
-                          {user.name}
-                        </TableCell>
-                        <TableCell>
-                          {user.email}
-                        </TableCell>
-                        <TableCell>
-                          {user.role?.name || 'No Role'}
-                        </TableCell>
-                        <TableCell>
-                          {editingRowKey === getRowKey(user) && editingRow ? (
-                            <select
-                              className="h-9 w-full border rounded-md px-2 text-sm bg-white"
-                              value={editingRow.leadGroup}
-                              onChange={(e) => setEditingRow((prev) => prev ? ({ ...prev, leadGroup: e.target.value }) : prev)}
-                            >
-                              <option value="">Select Group</option>
-                              {availableLeadGroups
-                                .map((group) => (
-                                  <option key={group.name} value={group.name}>
-                                    {group.name}
-                                  </option>
-                                ))}
-                            </select>
-                          ) : user.leadGroup}
-                        </TableCell>
-                        <TableCell>
-                          {editingRowKey === getRowKey(user) && editingRow ? (
-                            rowIsCse ? (
-                              <Input
-                                className="h-9"
-                                type="number"
-                                min="0"
-                                max="100"
-                                step="1"
-                                value={editingRow.supportResolveRateGoal}
-                                onChange={(e) =>
-                                  setEditingRow((prev) =>
-                                    prev ? ({ ...prev, supportResolveRateGoal: e.target.value }) : prev
-                                  )
-                                }
-                              />
-                            ) : (
-                              <Input
-                                className="h-9"
-                                type="number"
-                                min="0"
-                                step="1"
-                                value={editingRow.dailyTarget}
-                                onChange={(e) =>
-                                  setEditingRow((prev) =>
-                                    prev ? ({ ...prev, dailyTarget: e.target.value }) : prev
-                                  )
-                                }
-                              />
-                            )
-                          ) : rowIsCse ? (
-                            <>{formatResolveRateGoal(user.supportResolveRateGoal)}</>
-                          ) : (
-                            user.dailyTarget
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          {editingRowKey === getRowKey(user) && editingRow ? (
-                            rowIsCse ? (
-                              <SupportDailyDualInputs
-                                selfTrial={editingRow.supportDailyLimitSelfTrial}
-                                other={editingRow.supportDailyLimitOther}
-                                onSelfTrialChange={(value) =>
-                                  setEditingRow((prev) =>
-                                    prev ? ({ ...prev, supportDailyLimitSelfTrial: value }) : prev
-                                  )
-                                }
-                                onOtherChange={(value) =>
-                                  setEditingRow((prev) =>
-                                    prev ? ({ ...prev, supportDailyLimitOther: value }) : prev
-                                  )
-                                }
-                              />
-                            ) : (
-                              <Input
-                                className="h-9"
-                                type="number"
-                                min="0"
-                                step="1"
-                                value={editingRow.dailyLimit}
-                                onChange={(e) =>
-                                  setEditingRow((prev) =>
-                                    prev ? ({ ...prev, dailyLimit: e.target.value }) : prev
-                                  )
-                                }
-                              />
-                            )
-                          ) : rowIsCse ? (
-                            <SupportDailyDualDisplay
-                              selfTrial={user.supportDailyLimitSelfTrial}
-                              other={user.supportDailyLimitOther}
-                            />
-                          ) : (
-                            user.dailyLimit
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          {editingRowKey === getRowKey(user) && editingRow ? (
-                            <div className="relative" ref={editManagerDropdownRef}>
-                              <div className="flex gap-1">
-                                <div className="relative flex-1">
-                                  <Input
-                                    className="h-9 pr-8 text-sm"
-                                    placeholder="Search manager..."
-                                    value={showEditManagerDropdown ? editManagerSearch : editingRow.managerEmail}
-                                    onChange={(e) => {
-                                      setEditManagerSearch(e.target.value);
-                                      setShowEditManagerDropdown(true);
-                                    }}
-                                    onFocus={() => {
-                                      setEditManagerSearch('');
-                                      setShowEditManagerDropdown(true);
-                                    }}
-                                    autoComplete="off"
-                                  />
-                                  <Search className="absolute right-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400 pointer-events-none" />
-                                </div>
-                                {editingRow.managerEmail && (
-                                  <Button
-                                    type="button"
-                                    variant="outline"
-                                    size="icon"
-                                    className="h-9 w-9 shrink-0 border-gray-200 text-gray-500 hover:text-gray-700"
-                                    onClick={() => {
-                                      setEditingRow((prev) => prev ? ({ ...prev, managerEmail: '' }) : prev);
-                                      setEditManagerSearch('');
-                                      setShowEditManagerDropdown(false);
-                                    }}
-                                    title="Clear manager"
-                                  >
-                                    <X className="h-3.5 w-3.5" />
-                                  </Button>
-                                )}
-                              </div>
-                              {showEditManagerDropdown && (
-                                <div className="absolute z-50 mt-1 w-64 max-h-40 overflow-y-auto rounded-md border border-gray-200 bg-white shadow-lg">
-                                  {users
-                                    .filter((u) => {
-                                      if (u.email === user.email) return false;
-                                      if (!editManagerSearch.trim()) return true;
-                                      const q = editManagerSearch.toLowerCase();
-                                      return (u.name || '').toLowerCase().includes(q) || (u.email || '').toLowerCase().includes(q);
-                                    })
-                                    .map((u) => (
-                                      <button
-                                        key={u.uid}
-                                        type="button"
-                                        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-gray-100"
-                                        onMouseDown={(e) => e.preventDefault()}
-                                        onClick={() => {
-                                          setEditingRow((prev) => prev ? ({ ...prev, managerEmail: u.email }) : prev);
-                                          setEditManagerSearch('');
-                                          setShowEditManagerDropdown(false);
-                                        }}
-                                      >
-                                        <span className="font-medium truncate">{u.name}</span>
-                                        <span className="text-gray-400 truncate">{u.email}</span>
-                                      </button>
-                                    ))}
-                                  {users.filter((u) => {
-                                    if (u.email === user.email) return false;
-                                    if (!editManagerSearch.trim()) return true;
-                                    const q = editManagerSearch.toLowerCase();
-                                    return (u.name || '').toLowerCase().includes(q) || (u.email || '').toLowerCase().includes(q);
-                                  }).length === 0 && (
-                                    <div className="px-3 py-1.5 text-xs text-gray-400">No users found</div>
-                                  )}
-                                </div>
-                              )}
-                            </div>
-                          ) : user.managerEmail}
-                        </TableCell>
-                        <TableCell>
-                        {format(
-  new Date(new Date(user.created_at).getTime() + 5.5 * 60 * 60 * 1000),
-  'MMM d, yyyy h:mm a'
-)}
-                        </TableCell>
-                        <TableCell className="text-right">
-                          <div className="inline-flex items-center justify-end gap-2">
-                          {editingRowKey === getRowKey(user) ? (
-                            <>
-                              <Button
-                                variant="outline"
-                                size="icon"
-                                className="h-8 w-8 border-green-200 bg-green-50 text-green-700 hover:bg-green-100 hover:text-green-800"
-                                onClick={handleSaveRowEdit}
-                                disabled={isUpdatingRow}
-                                title="Save changes"
-                              >
-                                <Check className="h-4 w-4" />
-                              </Button>
-                              <Button
-                                variant="outline"
-                                size="icon"
-                                className="h-8 w-8 border-gray-200 bg-white text-gray-600 hover:bg-gray-100 hover:text-gray-800"
-                                onClick={handleCancelRowEdit}
-                                disabled={isUpdatingRow}
-                                title="Cancel editing"
-                              >
-                                <X className="h-4 w-4" />
-                              </Button>
-                            </>
-                          ) : (
-                            <Button
-                              variant="outline"
-                              size="icon"
-                              className="h-8 w-8 border-gray-200 bg-white text-gray-600 hover:bg-gray-100 hover:text-gray-800"
-                              onClick={() => handleEditUser(user)}
-                              title="Edit row"
-                            >
-                              <Pencil className="h-4 w-4" />
-                            </Button>
-                          )}
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            className="h-8 w-8 border-red-200 bg-white text-red-500 hover:bg-red-50 hover:text-red-700"
-                            onClick={() => handleDeleteUser(user.email, user.uid)}
-                            title="Delete user"
-                            disabled={editingRowKey === getRowKey(user)}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                          </div>
-                        </TableCell>
+                        {schema.columns
+                          .filter((column) => column !== 'actions')
+                          .map((column) => renderColumnCell(column, user))}
+                        {customTableFields.map((field) =>
+                          renderCustomTableCell(field, user, isEditing)
+                        )}
+                        {schema.columns.includes('actions') && renderColumnCell('actions', user)}
                       </TableRow>
                     );
                   })}

--- a/src/components/page-builder/add-user/types.ts
+++ b/src/components/page-builder/add-user/types.ts
@@ -23,6 +23,8 @@ export interface User {
   supportDailyLimitOther?: string | number;
   user_parent_id?: number | null;
   managerEmail?: string;
+  /** Tenant-defined custom field values (key → display value). */
+  customFields?: Record<string, string>;
 }
 
 export interface UserCoreSettingsSummary {
@@ -32,6 +34,7 @@ export interface UserCoreSettingsSummary {
   support_resolve_rate_goal?: number;
   support_daily_limit_self_trial?: number;
   support_daily_limit_other?: number;
+  custom_fields?: Record<string, string>;
 }
 
 export interface LeadGroupOption {
@@ -55,10 +58,23 @@ export interface RowEditState {
   supportDailyLimitSelfTrial: string;
   supportDailyLimitOther: string;
   managerEmail: string;
+  customFields: Record<string, string>;
 }
 
 export interface AddUserComponentConfig {
   userScope?: 'all' | 'under_me';
+  /** Form fields for this page (saved with page config — shared). */
+  umFormFields?: string[];
+  /** Table columns for this page (saved with page config — shared). */
+  umColumns?: string[];
+  /** Custom fields for this page (saved with page config — shared). */
+  umCustomFields?: Array<{
+    key: string;
+    label: string;
+    type: 'string' | 'number' | 'boolean';
+    showInForm: boolean;
+    showInTable: boolean;
+  }>;
 }
 
 export interface AddUserComponentProps {

--- a/src/components/page-builder/add-user/useAddUser.ts
+++ b/src/components/page-builder/add-user/useAddUser.ts
@@ -18,12 +18,15 @@ import type {
   AddUserComponentProps,
 } from './types';
 import { isCseRole, patchSupportDailyKv } from './utils';
+import { customFieldKvKey, isBoundCustomField } from './userManagementConfig';
+import { useUserManagementConfig } from './useUserManagementConfig';
 
 export function useAddUser({ config }: AddUserComponentProps) {
   const { user, session } = useAuth();
   const navigate = useNavigate();
   const { tenantSlug } = useParams<{ tenantSlug: string }>();
   const { tenantId } = useTenant();
+  const { schema } = useUserManagementConfig(config);
   const [roles, setRoles] = useState<Role[]>([]);
   const [users, setUsers] = useState<User[]>([]);
   const [myMembershipId, setMyMembershipId] = useState<number | null>(null);
@@ -41,6 +44,7 @@ export function useAddUser({ config }: AddUserComponentProps) {
     supportDailyLimitSelfTrial: '',
     supportDailyLimitOther: '',
     managerEmail: '',
+    customFields: {} as Record<string, string>,
   });
   const [isLoading, setIsLoading] = useState(true);
   const [showRoleFields, setShowRoleFields] = useState(false);
@@ -181,6 +185,15 @@ export function useAddUser({ config }: AddUserComponentProps) {
         const resolveGoalRow = kv.find((r) => r.key === 'SUPPORT_RESOLVE_RATE_GOAL');
         const stLimitRow = kv.find((r) => r.key === 'SUPPORT_DAILY_LIMIT_SELF_TRIAL');
         const otherLimitRow = kv.find((r) => r.key === 'SUPPORT_DAILY_LIMIT_OTHER');
+        const custom_fields: Record<string, string> = {};
+        kv.forEach((row) => {
+          if (typeof row.key === 'string' && row.key.startsWith('CUSTOM_FIELD_')) {
+            const fieldKey = row.key.slice('CUSTOM_FIELD_'.length).toLowerCase();
+            if (row.value != null && row.value !== '') {
+              custom_fields[fieldKey] = String(row.value);
+            }
+          }
+        });
         mapped[emailKey] = {
           group_id: typeof groupRow?.value === 'number' ? groupRow.value : undefined,
           daily_target: typeof targetRow?.value === 'number' ? targetRow.value : undefined,
@@ -191,6 +204,7 @@ export function useAddUser({ config }: AddUserComponentProps) {
             typeof stLimitRow?.value === 'number' ? stLimitRow.value : undefined,
           support_daily_limit_other:
             typeof otherLimitRow?.value === 'number' ? otherLimitRow.value : undefined,
+          custom_fields,
         };
       });
       setCoreSettingsMap(mapped);
@@ -266,6 +280,7 @@ export function useAddUser({ config }: AddUserComponentProps) {
             ? (config?.support_daily_limit_other ?? '—')
             : '—',
           managerEmail: parentUser?.email || '—',
+          customFields: config?.custom_fields ?? {},
         };
       }),
     [users, coreSettingsMap, availableLeadGroups]
@@ -452,6 +467,7 @@ export function useAddUser({ config }: AddUserComponentProps) {
       const selectedSupportResolveGoal = formData.supportResolveRateGoal;
       const selectedSupportStLimit = formData.supportDailyLimitSelfTrial;
       const selectedSupportOtherLimit = formData.supportDailyLimitOther;
+      const selectedCustomFields = { ...formData.customFields };
 
       setFormData({
         name: '',
@@ -464,6 +480,7 @@ export function useAddUser({ config }: AddUserComponentProps) {
         supportDailyLimitSelfTrial: '',
         supportDailyLimitOther: '',
         managerEmail: '',
+        customFields: {},
       });
       setSelectedQueueType('lead');
       setSelectedRoleId('');
@@ -471,6 +488,36 @@ export function useAddUser({ config }: AddUserComponentProps) {
       // Refresh the users list
       await fetchUsers();
       await fetchCoreSettings();
+
+      if (createdMembershipId && Object.keys(selectedCustomFields).length > 0) {
+        try {
+          const customPayload: Record<string, string | number | boolean | null> = {};
+          for (const [key, value] of Object.entries(selectedCustomFields)) {
+            if (isBoundCustomField(key)) continue;
+            const def = schema.customFields.find((f) => f.key === key);
+            if (value === '' || value == null) {
+              customPayload[customFieldKvKey(key)] = null;
+            } else if (def?.type === 'number') {
+              customPayload[customFieldKvKey(key)] = Number(value);
+            } else if (def?.type === 'boolean') {
+              customPayload[customFieldKvKey(key)] = value === 'true' || value === '1';
+            } else {
+              customPayload[customFieldKvKey(key)] = value;
+            }
+          }
+          await leadTypeAssignmentApi.patchCoreKvSettings(
+            String(createdMembershipId),
+            customPayload
+          );
+          await fetchCoreSettings();
+        } catch (customErr: any) {
+          toast.error(
+            customErr?.response?.data?.detail ||
+              customErr?.message ||
+              'User created but custom fields may not have saved'
+          );
+        }
+      }
 
       if (
         selectedQueueType === 'ticket' &&
@@ -610,6 +657,7 @@ export function useAddUser({ config }: AddUserComponentProps) {
           ? String(config.support_daily_limit_other)
           : '',
       managerEmail: usr.managerEmail && usr.managerEmail !== '—' ? usr.managerEmail : '',
+      customFields: { ...(usr.customFields || config?.custom_fields || {}) },
     });
   };
 
@@ -723,6 +771,35 @@ export function useAddUser({ config }: AddUserComponentProps) {
               patchError?.response?.data?.detail ||
                 patchError?.message ||
                 'User updated but failed to save support daily targets/limits'
+            );
+          }
+        }
+
+        if (Object.keys(editingRow.customFields || {}).length > 0) {
+          try {
+            const customPayload: Record<string, string | number | boolean | null> = {};
+            for (const [key, value] of Object.entries(editingRow.customFields)) {
+              if (isBoundCustomField(key)) continue;
+              const def = schema.customFields.find((f) => f.key === key);
+              if (value === '' || value == null) {
+                customPayload[customFieldKvKey(key)] = null;
+              } else if (def?.type === 'number') {
+                customPayload[customFieldKvKey(key)] = Number(value);
+              } else if (def?.type === 'boolean') {
+                customPayload[customFieldKvKey(key)] = value === 'true' || value === '1';
+              } else {
+                customPayload[customFieldKvKey(key)] = value;
+              }
+            }
+            await leadTypeAssignmentApi.patchCoreKvSettings(
+              String(editedUser.tenant_membership_id),
+              customPayload
+            );
+          } catch (customErr: any) {
+            toast.error(
+              customErr?.response?.data?.detail ||
+                customErr?.message ||
+                'User updated but custom fields may not have saved'
             );
           }
         }

--- a/src/components/page-builder/add-user/useUserManagementConfig.ts
+++ b/src/components/page-builder/add-user/useUserManagementConfig.ts
@@ -1,0 +1,80 @@
+import { useMemo } from "react";
+import { useParams } from "react-router-dom";
+import { useTenant } from "@/hooks/useTenant";
+import { getTenantSlug } from "@/lib/api/config";
+import {
+  FALLBACK_USER_MANAGEMENT_SCHEMA,
+  hasColumn,
+  hasFormField,
+  resolveUserManagementSchema,
+  type UserManagementColumn,
+  type UserManagementCustomField,
+  type UserManagementFormField,
+  type UserManagementSchema,
+} from "./userManagementConfig";
+
+export interface UserManagementPageConfig {
+  umFormFields?: string[];
+  umColumns?: string[];
+  umCustomFields?: UserManagementCustomField[];
+}
+
+/**
+ * User Management schema for this page widget.
+ * Page config (saved with the page) wins; else static tenant/defaults.
+ */
+export function useUserManagementConfig(pageConfig?: UserManagementPageConfig | null): {
+  schema: UserManagementSchema;
+  showField: (field: UserManagementFormField) => boolean;
+  showColumn: (column: UserManagementColumn) => boolean;
+  tenantSlug: string | null;
+  tenantId: string | null;
+  tenantKey: string | null;
+} {
+  const { tenantSlug: pathSlug } = useParams<{ tenantSlug?: string }>();
+  const { tenantId, tenantSlug: membershipSlug } = useTenant();
+
+  const tenantSlug =
+    pathSlug?.trim() ||
+    membershipSlug?.trim() ||
+    getTenantSlug() ||
+    null;
+  const id = tenantId?.trim() || null;
+  const tenantKey = tenantSlug || id;
+
+  const schema = useMemo(
+    () =>
+      resolveUserManagementSchema({
+        tenantId: id,
+        tenantSlug,
+        pageOverride: pageConfig
+          ? {
+              formFields: pageConfig.umFormFields,
+              columns: pageConfig.umColumns,
+              customFields: pageConfig.umCustomFields,
+            }
+          : null,
+      }),
+    [
+      id,
+      tenantSlug,
+      pageConfig?.umFormFields,
+      pageConfig?.umColumns,
+      pageConfig?.umCustomFields,
+    ]
+  );
+
+  const safeSchema: UserManagementSchema =
+    schema.formFields.length && schema.columns.length
+      ? schema
+      : FALLBACK_USER_MANAGEMENT_SCHEMA;
+
+  return {
+    schema: safeSchema,
+    showField: (field) => hasFormField(safeSchema, field),
+    showColumn: (column) => hasColumn(safeSchema, column),
+    tenantSlug,
+    tenantId: id,
+    tenantKey,
+  };
+}

--- a/src/components/page-builder/add-user/userManagementConfig.ts
+++ b/src/components/page-builder/add-user/userManagementConfig.ts
@@ -1,0 +1,307 @@
+/**
+ * User Management (Add User) schema.
+ * Base: `src/config/user-management.ts`
+ * Runtime: page widget config (saved with the page — shared for everyone).
+ *
+ * Built-ins: name, email, department, role (+ created_at, actions on table).
+ * Everything else is a custom field on the page config.
+ */
+
+import userManagementConfig from "@/config/user-management";
+
+/** Built-in form field keys (core user identity only). */
+export type UserManagementFormField = "name" | "email" | "department" | "role";
+
+/** Built-in table column keys. */
+export type UserManagementColumn =
+  | "name"
+  | "email"
+  | "department"
+  | "role"
+  | "created_at"
+  | "actions";
+
+/** Tenant-defined field (self-serve, not in the built-in catalog). */
+export interface UserManagementCustomField {
+  /** Stable key, e.g. "employee_code". */
+  key: string;
+  label: string;
+  type: "string" | "number" | "boolean";
+  showInForm: boolean;
+  showInTable: boolean;
+}
+
+export interface UserManagementSchema {
+  formFields: UserManagementFormField[];
+  columns: UserManagementColumn[];
+  /** Extra fields this tenant added themselves. */
+  customFields: UserManagementCustomField[];
+}
+
+export interface UserManagementConfigFile {
+  defaults: UserManagementSchema;
+  /** Keyed by membership tenant_slug or tenant_id. */
+  tenants: Record<string, UserManagementSchema>;
+}
+
+const CORE_FORM_FIELDS = new Set<UserManagementFormField>([
+  "name",
+  "email",
+  "department",
+  "role",
+]);
+
+const CORE_COLUMNS = new Set<UserManagementColumn>([
+  "name",
+  "email",
+  "department",
+  "role",
+  "created_at",
+  "actions",
+]);
+
+/** Former CRM built-ins — migrated into custom fields when found in old overrides. */
+const LEGACY_CRM_FORM_TO_CUSTOM: Record<
+  string,
+  { label: string; type: UserManagementCustomField["type"] }
+> = {
+  queue_type: { label: "Queue Type", type: "string" },
+  manager_email: { label: "Manager Email", type: "string" },
+  lead_group: { label: "Lead Group", type: "string" },
+  daily_target: { label: "Daily Target", type: "number" },
+  daily_limit: { label: "Daily Limit", type: "number" },
+  resolve_rate_goal: { label: "Resolve Goal %", type: "number" },
+  support_daily_limits: { label: "Support Daily Limits", type: "string" },
+};
+
+const LEGACY_CRM_COLUMN_TO_CUSTOM: Record<
+  string,
+  { label: string; type: UserManagementCustomField["type"] }
+> = {
+  group: { label: "Group", type: "string" },
+  target: { label: "Target", type: "number" },
+  daily_limit: { label: "Daily Limit", type: "number" },
+  manager_email: { label: "Manager Email", type: "string" },
+};
+
+/** Core built-ins — name, email, department, role (+ created_at/actions on table). */
+export const FALLBACK_USER_MANAGEMENT_SCHEMA: UserManagementSchema = {
+  formFields: ["name", "email", "department", "role"],
+  columns: ["name", "email", "department", "role", "created_at", "actions"],
+  customFields: [],
+};
+
+function isSchema(value: unknown): value is { formFields: unknown; columns: unknown; customFields?: unknown } {
+  if (!value || typeof value !== "object") return false;
+  const v = value as { formFields: unknown; columns: unknown };
+  return Array.isArray(v.formFields) && Array.isArray(v.columns);
+}
+
+function normalizeCustomFields(value: unknown): UserManagementCustomField[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((f) => f && typeof f === "object" && typeof (f as UserManagementCustomField).key === "string")
+    .map((f) => {
+      const field = f as UserManagementCustomField;
+      const type: UserManagementCustomField["type"] =
+        field.type === "number" || field.type === "boolean" ? field.type : "string";
+      return {
+        key: String(field.key).trim(),
+        label: String(field.label || field.key).trim() || field.key,
+        type,
+        showInForm: field.showInForm !== false,
+        showInTable: field.showInTable === true,
+      };
+    })
+    .filter((f) => f.key.length > 0);
+}
+
+function upsertCustomField(
+  list: UserManagementCustomField[],
+  field: UserManagementCustomField
+): UserManagementCustomField[] {
+  if (list.some((f) => f.key === field.key)) {
+    return list.map((f) =>
+      f.key === field.key
+        ? {
+            ...f,
+            showInForm: f.showInForm || field.showInForm,
+            showInTable: f.showInTable || field.showInTable,
+          }
+        : f
+    );
+  }
+  return [...list, field];
+}
+
+export function normalizeSchema(value: unknown): UserManagementSchema {
+  if (!isSchema(value) || (value.formFields as unknown[]).length === 0 || (value.columns as unknown[]).length === 0) {
+    return {
+      formFields: [...FALLBACK_USER_MANAGEMENT_SCHEMA.formFields],
+      columns: [...FALLBACK_USER_MANAGEMENT_SCHEMA.columns],
+      customFields: [],
+    };
+  }
+
+  const rawForm = value.formFields as string[];
+  const rawCols = value.columns as string[];
+  let customFields = normalizeCustomFields(value.customFields);
+
+  const formFields = rawForm.filter((f): f is UserManagementFormField =>
+    CORE_FORM_FIELDS.has(f as UserManagementFormField)
+  );
+
+  for (const key of rawForm) {
+    const meta = LEGACY_CRM_FORM_TO_CUSTOM[key];
+    if (!meta) continue;
+    customFields = upsertCustomField(customFields, {
+      key,
+      label: meta.label,
+      type: meta.type,
+      showInForm: true,
+      showInTable: false,
+    });
+  }
+
+  const columns = rawCols.filter((c): c is UserManagementColumn =>
+    CORE_COLUMNS.has(c as UserManagementColumn)
+  );
+
+  for (const key of rawCols) {
+    const meta = LEGACY_CRM_COLUMN_TO_CUSTOM[key];
+    if (!meta) continue;
+    customFields = upsertCustomField(customFields, {
+      key: key === "group" ? "lead_group" : key === "target" ? "daily_target" : key,
+      label: meta.label,
+      type: meta.type,
+      showInForm: false,
+      showInTable: true,
+    });
+  }
+
+  return {
+    formFields: formFields.length ? formFields : [...FALLBACK_USER_MANAGEMENT_SCHEMA.formFields],
+    columns: columns.length ? columns : [...FALLBACK_USER_MANAGEMENT_SCHEMA.columns],
+    customFields,
+  };
+}
+
+/** Sanitize a label into a stable custom field key. */
+export function slugifyCustomFieldKey(label: string): string {
+  const base = label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 40);
+  return base || `custom_${Date.now()}`;
+}
+
+/** Core-KV key used to persist a custom field value for a user. */
+export function customFieldKvKey(fieldKey: string): string {
+  return `CUSTOM_FIELD_${fieldKey.trim().toUpperCase()}`;
+}
+
+/**
+ * Custom field keys that are NOT stored as CUSTOM_FIELD_* KV.
+ * They bind to hierarchy / dedicated user-settings keys instead.
+ */
+export const BOUND_CUSTOM_FIELD_KEYS = new Set([
+  "manager_email",
+  "lead_group",
+  "daily_target",
+  "daily_limit",
+  "resolve_rate_goal",
+  "support_daily_limits",
+  "queue_type",
+]);
+
+export function isBoundCustomField(key: string): boolean {
+  return BOUND_CUSTOM_FIELD_KEYS.has(key);
+}
+
+const raw = userManagementConfig as unknown as Partial<UserManagementConfigFile> | null;
+
+const config: UserManagementConfigFile = {
+  defaults: normalizeSchema(raw?.defaults),
+  tenants:
+    raw?.tenants && typeof raw.tenants === "object"
+      ? Object.fromEntries(
+          Object.entries(raw.tenants).map(([key, schema]) => [key, normalizeSchema(schema)])
+        )
+      : {},
+};
+
+const COLUMN_LABELS: Record<UserManagementColumn, string> = {
+  name: "Name",
+  email: "Email",
+  department: "Department",
+  role: "Role",
+  created_at: "Created at",
+  actions: "",
+};
+
+export function getUserManagementConfig(): UserManagementConfigFile {
+  return config;
+}
+
+export function getColumnLabel(column: UserManagementColumn): string {
+  return COLUMN_LABELS[column] ?? column;
+}
+
+export type UserManagementPageOverride = {
+  formFields?: string[];
+  columns?: string[];
+  customFields?: UserManagementCustomField[];
+};
+
+/**
+ * Resolve User Management schema.
+ * Order: page widget config (shared via page save) → static tenant entry → defaults.
+ */
+export function resolveUserManagementSchema(input: {
+  tenantId?: string | null;
+  tenantSlug?: string | null;
+  pageOverride?: UserManagementPageOverride | null;
+}): UserManagementSchema {
+  try {
+    const slug = input.tenantSlug?.trim() || null;
+    const id = input.tenantId?.trim() || null;
+    const { tenants, defaults } = getUserManagementConfig();
+    const base =
+      (slug && tenants[slug] && normalizeSchema(tenants[slug])) ||
+      (id && tenants[id] && normalizeSchema(tenants[id])) ||
+      normalizeSchema(defaults);
+
+    const page = input.pageOverride;
+    const hasPageSchema =
+      !!page &&
+      (Array.isArray(page.formFields) ||
+        Array.isArray(page.columns) ||
+        Array.isArray(page.customFields));
+
+    if (!hasPageSchema || !page) return base;
+
+    return normalizeSchema({
+      formFields: page.formFields ?? base.formFields,
+      columns: page.columns ?? base.columns,
+      customFields: page.customFields ?? base.customFields,
+    });
+  } catch {
+    return normalizeSchema(FALLBACK_USER_MANAGEMENT_SCHEMA);
+  }
+}
+
+export function hasFormField(
+  schema: UserManagementSchema,
+  field: UserManagementFormField
+): boolean {
+  return schema.formFields.includes(field);
+}
+
+export function hasColumn(
+  schema: UserManagementSchema,
+  column: UserManagementColumn
+): boolean {
+  return schema.columns.includes(column);
+}

--- a/src/components/page-builder/component-config/AddUserConfig.tsx
+++ b/src/components/page-builder/component-config/AddUserConfig.tsx
@@ -1,0 +1,373 @@
+import React, { useMemo, useState } from "react";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Trash2, Plus } from "lucide-react";
+import {
+  slugifyCustomFieldKey,
+  type UserManagementColumn,
+  type UserManagementCustomField,
+  type UserManagementFormField,
+  type UserManagementSchema,
+} from "@/components/page-builder/add-user/userManagementConfig";
+import { useUserManagementConfig } from "@/components/page-builder/add-user/useUserManagementConfig";
+
+const FORM_FIELD_OPTIONS: { key: UserManagementFormField; label: string }[] = [
+  { key: "name", label: "Full Name" },
+  { key: "email", label: "Email" },
+  { key: "department", label: "Department" },
+  { key: "role", label: "Role" },
+];
+
+const COLUMN_OPTIONS: { key: UserManagementColumn; label: string }[] = [
+  { key: "name", label: "Name" },
+  { key: "email", label: "Email" },
+  { key: "department", label: "Department" },
+  { key: "role", label: "Role" },
+  { key: "created_at", label: "Created at" },
+  { key: "actions", label: "Actions" },
+];
+
+export interface AddUserConfigLocal {
+  userScope?: "all" | "under_me";
+  umFormFields?: string[];
+  umColumns?: string[];
+  umCustomFields?: UserManagementCustomField[];
+}
+
+interface AddUserConfigProps {
+  localConfig: AddUserConfigLocal;
+  handleInputChange: (field: string, value: unknown) => void;
+  handleConfigPatch?: (patch: Partial<AddUserConfigLocal>) => void;
+}
+
+function toggleInList<T extends string>(list: T[], key: T, enabled: boolean): T[] {
+  if (enabled) {
+    return list.includes(key) ? list : [...list, key];
+  }
+  return list.filter((item) => item !== key);
+}
+
+/**
+ * Page-builder config for User Management.
+ * Schema is stored on the page widget and saved with the page (shared for all users).
+ */
+export function AddUserConfig({
+  localConfig,
+  handleInputChange,
+  handleConfigPatch,
+}: AddUserConfigProps) {
+  const { schema, tenantSlug, tenantId } = useUserManagementConfig(localConfig);
+  const [newLabel, setNewLabel] = useState("");
+  const [newType, setNewType] = useState<"string" | "number" | "boolean">("string");
+  const [newShowForm, setNewShowForm] = useState(true);
+  const [newShowTable, setNewShowTable] = useState(true);
+
+  const formFields = useMemo(() => [...schema.formFields], [schema.formFields]);
+  const columns = useMemo(() => [...schema.columns], [schema.columns]);
+  const customFields = useMemo(
+    () => [...(schema.customFields ?? [])],
+    [schema.customFields]
+  );
+
+  const saveSchema = (next: UserManagementSchema) => {
+    const patch = {
+      umFormFields: [...next.formFields],
+      umColumns: [...next.columns],
+      umCustomFields: (next.customFields ?? []).map((f) => ({ ...f })),
+    };
+    if (handleConfigPatch) {
+      handleConfigPatch(patch);
+    } else {
+      handleInputChange("umFormFields", patch.umFormFields);
+      handleInputChange("umColumns", patch.umColumns);
+      handleInputChange("umCustomFields", patch.umCustomFields);
+    }
+  };
+
+  const handleAddCustomField = () => {
+    const label = newLabel.trim();
+    if (!label) return;
+    let key = slugifyCustomFieldKey(label);
+    const existing = new Set(customFields.map((f) => f.key));
+    if (existing.has(key)) {
+      key = `${key}_${Date.now().toString(36).slice(-4)}`;
+    }
+    const field: UserManagementCustomField = {
+      key,
+      label,
+      type: newType,
+      showInForm: newShowForm,
+      showInTable: newShowTable,
+    };
+    saveSchema({
+      formFields,
+      columns,
+      customFields: [...customFields, field],
+    });
+    setNewLabel("");
+    setNewType("string");
+    setNewShowForm(true);
+    setNewShowTable(true);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-md border border-border bg-muted/40 px-3 py-2 space-y-1">
+        <p className="text-xs font-medium text-foreground">Saved with this page</p>
+        <p className="text-xs text-muted-foreground">
+          Field settings apply to everyone who opens this User Management page
+          {tenantSlug || tenantId ? (
+            <>
+              {" "}
+              (
+              <span className="font-mono text-foreground">
+                {tenantSlug || tenantId}
+              </span>
+              )
+            </>
+          ) : null}
+          . Save the page after changes.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label>User Scope</Label>
+        <select
+          className="h-9 w-full border rounded-md px-3 text-sm bg-background"
+          value={localConfig.userScope || "all"}
+          onChange={(e) => handleInputChange("userScope", e.target.value)}
+        >
+          <option value="all">Show all users</option>
+          <option value="under_me">Show only users under me</option>
+        </select>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <Label className="text-sm font-semibold">Built-in form fields</Label>
+          <p className="text-xs text-muted-foreground mt-1">
+            Name, email, department, role
+          </p>
+        </div>
+        <div className="space-y-2 rounded-md border border-border p-3">
+          {FORM_FIELD_OPTIONS.map((opt) => {
+            const checked = formFields.includes(opt.key);
+            return (
+              <div key={opt.key} className="flex items-center justify-between gap-3">
+                <Label htmlFor={`um-form-${opt.key}`} className="text-sm font-normal cursor-pointer">
+                  {opt.label}
+                </Label>
+                <Switch
+                  id={`um-form-${opt.key}`}
+                  checked={checked}
+                  onCheckedChange={(next) =>
+                    saveSchema({
+                      formFields: toggleInList(formFields, opt.key, next),
+                      columns,
+                      customFields,
+                    })
+                  }
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <Label className="text-sm font-semibold">Built-in table columns</Label>
+          <p className="text-xs text-muted-foreground mt-1">
+            Name, email, department, role, created at, actions
+          </p>
+        </div>
+        <div className="space-y-2 rounded-md border border-border p-3">
+          {COLUMN_OPTIONS.map((opt) => {
+            const checked = columns.includes(opt.key);
+            return (
+              <div key={opt.key} className="flex items-center justify-between gap-3">
+                <Label htmlFor={`um-col-${opt.key}`} className="text-sm font-normal cursor-pointer">
+                  {opt.label}
+                </Label>
+                <Switch
+                  id={`um-col-${opt.key}`}
+                  checked={checked}
+                  onCheckedChange={(next) =>
+                    saveSchema({
+                      formFields,
+                      columns: toggleInList(columns, opt.key, next),
+                      customFields,
+                    })
+                  }
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <Label className="text-sm font-semibold">Custom fields</Label>
+          <p className="text-xs text-muted-foreground mt-1">
+            Add lead group, daily target, manager email, or any other field this page needs.
+          </p>
+        </div>
+
+        {customFields.length > 0 && (
+          <div className="space-y-2 rounded-md border border-border p-3">
+            {customFields.map((field) => (
+              <div
+                key={field.key}
+                className="flex flex-col gap-2 border-b border-border/60 pb-3 last:border-0 last:pb-0"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium truncate">{field.label}</p>
+                    <p className="text-xs text-muted-foreground font-mono">{field.key}</p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 shrink-0 text-destructive"
+                    onClick={() =>
+                      saveSchema({
+                        formFields,
+                        columns,
+                        customFields: customFields.filter((f) => f.key !== field.key),
+                      })
+                    }
+                    title="Remove custom field"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+                <div className="flex flex-wrap gap-4">
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      id={`cf-form-${field.key}`}
+                      checked={field.showInForm}
+                      onCheckedChange={(next) =>
+                        saveSchema({
+                          formFields,
+                          columns,
+                          customFields: customFields.map((f) =>
+                            f.key === field.key ? { ...f, showInForm: next } : f
+                          ),
+                        })
+                      }
+                    />
+                    <Label htmlFor={`cf-form-${field.key}`} className="text-xs font-normal">
+                      Form
+                    </Label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      id={`cf-table-${field.key}`}
+                      checked={field.showInTable}
+                      onCheckedChange={(next) =>
+                        saveSchema({
+                          formFields,
+                          columns,
+                          customFields: customFields.map((f) =>
+                            f.key === field.key ? { ...f, showInTable: next } : f
+                          ),
+                        })
+                      }
+                    />
+                    <Label htmlFor={`cf-table-${field.key}`} className="text-xs font-normal">
+                      Table
+                    </Label>
+                  </div>
+                  <span className="text-xs text-muted-foreground self-center">{field.type}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="space-y-3 rounded-md border border-dashed border-border p-3">
+          <Label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Add custom field
+          </Label>
+          <div className="space-y-2">
+            <Input
+              placeholder="Label (e.g. Lead Group, Daily Target)"
+              value={newLabel}
+              onChange={(e) => setNewLabel(e.target.value)}
+            />
+            <select
+              className="h-9 w-full border rounded-md px-3 text-sm bg-background"
+              value={newType}
+              onChange={(e) =>
+                setNewType(e.target.value as "string" | "number" | "boolean")
+              }
+            >
+              <option value="string">Text</option>
+              <option value="number">Number</option>
+              <option value="boolean">Yes / No</option>
+            </select>
+            <div className="flex flex-wrap gap-4">
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="new-cf-form"
+                  checked={newShowForm}
+                  onCheckedChange={setNewShowForm}
+                />
+                <Label htmlFor="new-cf-form" className="text-xs font-normal">
+                  Show in form
+                </Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="new-cf-table"
+                  checked={newShowTable}
+                  onCheckedChange={setNewShowTable}
+                />
+                <Label htmlFor="new-cf-table" className="text-xs font-normal">
+                  Show in table
+                </Label>
+              </div>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              className="w-full"
+              disabled={!newLabel.trim()}
+              onClick={handleAddCustomField}
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              Add field
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="w-full"
+        onClick={() => {
+          const patch = {
+            umFormFields: undefined,
+            umColumns: undefined,
+            umCustomFields: undefined,
+          };
+          if (handleConfigPatch) {
+            handleConfigPatch(patch);
+          } else {
+            handleInputChange("umFormFields", undefined);
+            handleInputChange("umColumns", undefined);
+            handleInputChange("umCustomFields", undefined);
+          }
+        }}
+      >
+        Reset to config defaults
+      </Button>
+    </div>
+  );
+}

--- a/src/config/user-management.ts
+++ b/src/config/user-management.ts
@@ -1,0 +1,115 @@
+/**
+ * Default User Management columns/fields per tenant.
+ * Page widget config (saved with the page) overrides this at runtime.
+ * Built-ins: name, email, department, role (+ created_at/actions on table).
+ * Former CRM extras live under customFields so tenants can edit them in the panel.
+ */
+
+const CRM_CUSTOM_FIELDS_FULL = [
+  {
+    key: "queue_type",
+    label: "Queue Type",
+    type: "string" as const,
+    showInForm: true,
+    showInTable: false,
+  },
+  {
+    key: "manager_email",
+    label: "Manager Email",
+    type: "string" as const,
+    showInForm: true,
+    showInTable: true,
+  },
+  {
+    key: "lead_group",
+    label: "Lead Group",
+    type: "string" as const,
+    showInForm: true,
+    showInTable: true,
+  },
+  {
+    key: "daily_target",
+    label: "Daily Target",
+    type: "number" as const,
+    showInForm: true,
+    showInTable: true,
+  },
+  {
+    key: "daily_limit",
+    label: "Daily Limit",
+    type: "number" as const,
+    showInForm: true,
+    showInTable: true,
+  },
+  {
+    key: "resolve_rate_goal",
+    label: "Resolve Goal %",
+    type: "number" as const,
+    showInForm: true,
+    showInTable: false,
+  },
+  {
+    key: "support_daily_limits",
+    label: "Support Daily Limits",
+    type: "string" as const,
+    showInForm: true,
+    showInTable: false,
+  },
+];
+
+const userManagementConfig = {
+  defaults: {
+    formFields: ["name", "email", "department", "role"],
+    columns: ["name", "email", "department", "role", "created_at", "actions"],
+    customFields: CRM_CUSTOM_FIELDS_FULL,
+  },
+  tenants: {
+    "bibhab-thepyro-ai": {
+      formFields: ["name", "email", "department", "role"],
+      columns: ["name", "email", "department", "role", "created_at", "actions"],
+      customFields: CRM_CUSTOM_FIELDS_FULL,
+    },
+    "acme-crm": {
+      formFields: ["name", "email", "department", "role"],
+      columns: ["name", "email", "department", "role", "created_at", "actions"],
+      customFields: [
+        {
+          key: "lead_group",
+          label: "Lead Group",
+          type: "string" as const,
+          showInForm: true,
+          showInTable: true,
+        },
+        {
+          key: "daily_target",
+          label: "Daily Target",
+          type: "number" as const,
+          showInForm: true,
+          showInTable: true,
+        },
+        {
+          key: "daily_limit",
+          label: "Daily Limit",
+          type: "number" as const,
+          showInForm: true,
+          showInTable: true,
+        },
+      ],
+    },
+    "beta-crm": {
+      formFields: ["name", "email", "department", "role"],
+      columns: ["name", "email", "department", "role", "created_at", "actions"],
+      customFields: [
+        {
+          key: "manager_email",
+          label: "Manager Email",
+          type: "string" as const,
+          showInForm: true,
+          showInTable: true,
+        },
+      ],
+    },
+  },
+};
+
+export default userManagementConfig;

--- a/src/features/page-builder/ConfigurationPanel.tsx
+++ b/src/features/page-builder/ConfigurationPanel.tsx
@@ -35,6 +35,7 @@ import { WhatsAppTemplateConfig } from "@/components/page-builder/component-conf
 import { FileUploadConfig } from "@/components/ATScomponents/configs/FileUploadConfig";
 import { DispatchCardListConfigPanel } from "@/components/page-builder/component-config/DispatchCardListConfig";
 import { DispatchDashboardConfigPanel } from "@/components/page-builder/component-config/DispatchDashboardConfig";
+import { AddUserConfig } from "@/components/page-builder/component-config/AddUserConfig";
 import type { FilterConfig } from "@/component-config/DynamicFilterConfig";
 import type { CanvasComponentData, ComponentConfig } from "./componentMap";
 
@@ -115,6 +116,15 @@ export const ConfigurationPanel: React.FC<ConfigurationPanelProps> = ({ selected
     showDiagram?: boolean;
     // AddUser specific fields
     userScope?: 'all' | 'under_me';
+    umFormFields?: string[];
+    umColumns?: string[];
+    umCustomFields?: Array<{
+      key: string;
+      label: string;
+      type: 'string' | 'number' | 'boolean';
+      showInForm: boolean;
+      showInTable: boolean;
+    }>;
     // InventoryRequestForm specific fields
     initialStatus?: string;
     initialStatusText?: string;
@@ -210,6 +220,9 @@ export const ConfigurationPanel: React.FC<ConfigurationPanelProps> = ({ selected
     showDiagram: initialConfig.showDiagram !== false,
     // AddUser
     userScope: (initialConfig as any).userScope || 'all',
+    umFormFields: (initialConfig as any).umFormFields ?? undefined,
+    umColumns: (initialConfig as any).umColumns ?? undefined,
+    umCustomFields: (initialConfig as any).umCustomFields ?? undefined,
     // InventoryRequestForm (empty by default so user can set from config)
     initialStatus: (initialConfig as any).initialStatus ?? (initialConfig as any).defaultStatus ?? '',
     initialStatusText: (initialConfig as any).initialStatusText ?? '',
@@ -786,17 +799,11 @@ export const ConfigurationPanel: React.FC<ConfigurationPanelProps> = ({ selected
 
       case 'addUser':
         return (
-          <div className="space-y-3">
-            <Label>User Scope</Label>
-            <select
-              className="h-9 w-full border rounded-md px-3 text-sm bg-white"
-              value={localConfig.userScope || 'all'}
-              onChange={(e) => handleInputChange('userScope', e.target.value)}
-            >
-              <option value="all">Show all users</option>
-              <option value="under_me">Show only users under me</option>
-            </select>
-          </div>
+          <AddUserConfig
+            localConfig={localConfig as any}
+            handleInputChange={handleInputChange}
+            handleConfigPatch={handleConfigPatch}
+          />
         );
 
       case 'userHierarchy':

--- a/src/features/page-builder/componentMap.ts
+++ b/src/features/page-builder/componentMap.ts
@@ -120,6 +120,17 @@ export interface ComponentConfig {
   // UserHierarchy specific fields
   showTable?: boolean;
   showDiagram?: boolean;
+  // AddUser / User Management
+  userScope?: 'all' | 'under_me';
+  umFormFields?: string[];
+  umColumns?: string[];
+  umCustomFields?: Array<{
+    key: string;
+    label: string;
+    type: 'string' | 'number' | 'boolean';
+    showInForm: boolean;
+    showInTable: boolean;
+  }>;
   // InventoryRequestForm specific fields
   entityType?: string;
   initialStatus?: string;

--- a/src/hooks/useTenant.ts
+++ b/src/hooks/useTenant.ts
@@ -4,6 +4,8 @@ import { membershipService } from '@/lib/api';
 
 export interface TenantContext {
   tenantId: string | null;
+  /** Slug from membership API (used for tenant-scoped config lookups). */
+  tenantSlug: string | null;
   role: 'owner' | 'editor' | 'viewer' | null;
   customRole: string | null;
   /** Tenant membership id for API placeholders (pyro_user_id, etc.). */
@@ -17,6 +19,7 @@ export interface TenantContext {
 export function useTenant(): TenantContext {
   const { user, session } = useAuth();
   const [tenantId, setTenantId] = useState<string | null>(null);
+  const [tenantSlug, setTenantSlug] = useState<string | null>(null);
   const [role, setRole] = useState<'owner' | 'editor' | 'viewer' | null>(null);
   const [customRole, setCustomRole] = useState<string | null>(null);
   const [membershipId, setMembershipId] = useState<string | null>(null);
@@ -39,6 +42,7 @@ export function useTenant(): TenantContext {
     async function fetchTenant() {
       if (!user || !session?.access_token) {
         setTenantId(null);
+        setTenantSlug(null);
         setRole(null);
         setCustomRole(null);
         setMembershipId(null);
@@ -49,16 +53,19 @@ export function useTenant(): TenantContext {
         const membership = await membershipService.getMyMembership();
         if (membership?.tenant_id) {
           setTenantId(membership.tenant_id);
+          const slug = membership.tenant_slug?.trim() || null;
+          setTenantSlug(slug);
           setRole('owner');
           if (membership.role_key) setCustomRole(membership.role_key);
           else await fetchCustomRole();
           const id = membership.tenant_membership_id;
           if (id != null) setMembershipId(String(id));
-          if (membership.tenant_slug && typeof window !== 'undefined') {
-            localStorage.setItem('tenant_slug', membership.tenant_slug);
+          if (slug && typeof window !== 'undefined') {
+            localStorage.setItem('tenant_slug', slug);
           }
         } else {
           setTenantId(null);
+          setTenantSlug(null);
           setRole(null);
           setCustomRole(null);
           setMembershipId(null);
@@ -83,5 +90,13 @@ export function useTenant(): TenantContext {
     return () => document.removeEventListener('visibilitychange', onVisibilityChange);
   }, [user, session?.access_token, fetchCustomRole]);
 
-  return { tenantId, role, customRole, membershipId, membershipLoaded, refetchCustomRole: fetchCustomRole };
+  return {
+    tenantId,
+    tenantSlug,
+    role,
+    customRole,
+    membershipId,
+    membershipLoaded,
+    refetchCustomRole: fetchCustomRole,
+  };
 } 

--- a/src/lib/api/services/userSettings.ts
+++ b/src/lib/api/services/userSettings.ts
@@ -293,6 +293,18 @@ export const leadTypeAssignmentApi = {
     );
     return Array.isArray(response.data) ? response.data : [];
   },
+
+  /** Patch arbitrary core-KV keys (used for tenant custom User Management fields). */
+  async patchCoreKvSettings(
+    userId: string,
+    data: Record<string, string | number | boolean | null>
+  ): Promise<UserCoreKVSetting[]> {
+    const response = await apiClient.patch(
+      `/user-settings/users/${userId}/core-kv-settings/`,
+      data
+    );
+    return Array.isArray(response.data) ? response.data : [];
+  },
 };
 
 export const groupsApi = {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,


### PR DESCRIPTION
Store schema on the page widget config so everyone sees the same fields after save, keep CRM extras as bound custom fields, and support tenant defaults plus generic CUSTOM_FIELD_* values.