### PR TITLE
Fix lead action bar overflow and Call Back footer on tablet-PROD 7 AUG

### DIFF
--- a/src/components/page-builder/CallBackModal.tsx
+++ b/src/components/page-builder/CallBackModal.tsx
@@ -101,8 +101,8 @@ export const CallBackModal: React.FC<CallBackModalProps> = ({
   return (
     <Dialog
       open={open}
-      onOpenChange={(open) => {
-        if (!open) {
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
           handleClose();
         }
       }}
@@ -110,24 +110,28 @@ export const CallBackModal: React.FC<CallBackModalProps> = ({
       <DialogPortal>
         {/* No overlay - modal slides in from right without blocking main content */}
         <DialogPrimitive.Content
-  onWheel={(e) => e.stopPropagation()}
-  onTouchMove={(e) => e.stopPropagation()}
-  className={cn(
-    "fixed inset-y-0 right-0 left-auto top-0 h-screen w-full max-w-[320px]",
-    "rounded-none border-l border-[#ded8d2] bg-[#f9f6f2] p-0 shadow-2xl z-[200]",
-    "flex flex-col overflow-hidden",
-    "data-[state=open]:animate-in data-[state=closed]:animate-out",
-    "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
-    "sm:w-[320px]"
-  )}
+          onWheel={(e) => e.stopPropagation()}
+          className={cn(
+            // inset-y-0 sizes to the visible viewport; avoid h-screen (pushes footer below fold on tablets)
+            "fixed inset-y-0 right-0 left-auto top-0 z-[200] flex h-full max-h-[100dvh] w-full max-w-[320px] flex-col overflow-hidden",
+            "rounded-none border-l border-[#ded8d2] bg-[#f9f6f2] p-0 shadow-2xl",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+            "sm:w-[320px]"
+          )}
           aria-describedby="callback-dialog-description"
           style={{ zIndex: 200 }}
         >
-          <div className="flex h-screen flex-col">
-            <div className="border-b border-[#e7e1db] px-4 py-4 flex-shrink-0 flex items-center justify-between">
-              <div className="space-y-1">
-                <DialogPrimitive.Title className="text-[20px] font-semibold text-black">Select time</DialogPrimitive.Title>
-                <DialogPrimitive.Description id="callback-dialog-description" className="text-sm text-[#8c8176]">
+          <div className="flex h-full min-h-0 flex-col">
+            <div className="flex flex-shrink-0 items-center justify-between border-b border-[#e7e1db] px-4 py-4">
+              <div className="space-y-1 pr-2">
+                <DialogPrimitive.Title className="text-[20px] font-semibold text-black">
+                  Select time
+                </DialogPrimitive.Title>
+                <DialogPrimitive.Description
+                  id="callback-dialog-description"
+                  className="text-sm text-[#8c8176]"
+                >
                   Optionally pick a time within the next 48 hours, or save without a time.
                 </DialogPrimitive.Description>
               </div>
@@ -136,64 +140,64 @@ export const CallBackModal: React.FC<CallBackModalProps> = ({
                 <span className="sr-only">Close</span>
               </DialogPrimitive.Close>
             </div>
+
             <div
-  className="flex-1 overflow-y-auto overscroll-contain px-4 py-4 space-y-6"
-  style={{
-    WebkitOverflowScrolling: "touch",
-  }}
->
-            {callbackSlotSections.map((section) => (
-              <div key={section.label} className="space-y-3">
-                <p className="text-sm font-semibold text-[#9b8f84]">{section.label}</p>
-                <div className="grid grid-cols-2 gap-2">
-                  {section.slots.map((slot) => {
-                    const isSelected = selectedCallbackSlot === slot.iso;
-                    return (
-                      <button
-                        key={slot.id}
-                        type="button"
-                        disabled={slot.disabled}
-                        onClick={() => setSelectedCallbackSlot(slot.iso)}
-                        className={cn(
-                          "rounded-full px-4 py-2 text-sm font-medium transition shadow-inner",
-                          slot.disabled
-                            ? "cursor-not-allowed bg-[#e8e3dd] text-[#b7aea4]"
-                            : isSelected
-                            ? "bg-black text-white shadow-md"
-                            : "bg-[#efe8e1] text-[#6d5f54] hover:bg-[#e7dfd7]"
-                        )}
-                      >
-                        {slot.label.toLowerCase()}
-                      </button>
-                    );
-                  })}
+              className="min-h-0 flex-1 space-y-6 overflow-y-auto overscroll-contain px-4 py-4"
+              style={{ WebkitOverflowScrolling: "touch" }}
+            >
+              {callbackSlotSections.map((section) => (
+                <div key={section.label} className="space-y-3">
+                  <p className="text-sm font-semibold text-[#9b8f84]">{section.label}</p>
+                  <div className="grid grid-cols-2 gap-2">
+                    {section.slots.map((slot) => {
+                      const isSelected = selectedCallbackSlot === slot.iso;
+                      return (
+                        <button
+                          key={slot.id}
+                          type="button"
+                          disabled={slot.disabled}
+                          onClick={() => setSelectedCallbackSlot(slot.iso)}
+                          className={cn(
+                            "rounded-full px-4 py-2 text-sm font-medium transition shadow-inner",
+                            slot.disabled
+                              ? "cursor-not-allowed bg-[#e8e3dd] text-[#b7aea4]"
+                              : isSelected
+                              ? "bg-black text-white shadow-md"
+                              : "bg-[#efe8e1] text-[#6d5f54] hover:bg-[#e7dfd7]"
+                          )}
+                        >
+                          {slot.label.toLowerCase()}
+                        </button>
+                      );
+                    })}
+                  </div>
                 </div>
+              ))}
+            </div>
+
+            {/* Pinned footer — always visible on tablet/desktop/mobile */}
+            <div className="flex-shrink-0 border-t border-[#e7e1db] bg-[#f4efe9] px-4 py-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
+              <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                <CustomButton
+                  variant="ghost"
+                  className="w-full sm:w-auto rounded-full border border-transparent text-black hover:border-black hover:bg-transparent"
+                  onClick={handleClose}
+                >
+                  Close
+                </CustomButton>
+                <CustomButton
+                  className="w-full sm:w-auto rounded-full bg-black text-white hover:bg-black/90"
+                  onClick={handleSubmit}
+                  disabled={updating}
+                  loading={updating}
+                >
+                  Save
+                </CustomButton>
               </div>
-            ))}
-          </div>
-          <div className="border-t border-[#e7e1db] px-4 py-4 space-y-4 flex-shrink-0 bg-[#f4efe9]">
-            <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
-              <CustomButton
-                variant="ghost"
-                className="w-full sm:w-auto rounded-full border border-transparent text-black hover:border-black hover:bg-transparent"
-                onClick={handleClose}
-              >
-                Close
-              </CustomButton>
-              <CustomButton
-                className="w-full sm:w-auto rounded-full bg-black text-white hover:bg-black/90"
-                onClick={handleSubmit}
-                disabled={updating}
-                loading={updating}
-              >
-                Save
-              </CustomButton>
             </div>
           </div>
-        </div>
-      </DialogPrimitive.Content>
+        </DialogPrimitive.Content>
       </DialogPortal>
     </Dialog>
   );
 };
-

--- a/src/components/page-builder/LeadActionButton.tsx
+++ b/src/components/page-builder/LeadActionButton.tsx
@@ -42,8 +42,8 @@ export const LeadActionButton: React.FC<LeadActionButtonProps> = ({
       disabled={disabled || loading}
       onClick={onClick}
       className={cn(
-        "h-12 rounded-xl border border-transparent px-4 text-sm font-semibold shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2",
-        "flex items-center justify-center gap-2 text-sm font-medium",
+        "h-auto min-h-12 rounded-xl border border-transparent px-2 py-2.5 md:px-2.5 lg:px-4 text-xs md:text-sm font-semibold shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2",
+        "inline-flex w-full max-w-full min-w-0 items-center justify-center gap-1.5 md:gap-2 font-medium !whitespace-normal text-center leading-tight",
         toneStyles[tone],
         (disabled || loading) &&
           "cursor-not-allowed opacity-60 hover:bg-inherit",
@@ -52,13 +52,13 @@ export const LeadActionButton: React.FC<LeadActionButtonProps> = ({
     >
       {loading ? (
         <>
-          <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-b-transparent" />
-          <span>{label}</span>
+          <span className="h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-current border-b-transparent" />
+          <span className="min-w-0 break-words">{label}</span>
         </>
       ) : (
         <>
-          <Icon className="h-4 w-4 text-[#61646B]" strokeWidth={2} />
-          <span>{label}</span>
+          <Icon className="h-4 w-4 shrink-0 text-[#61646B]" strokeWidth={2} />
+          <span className="min-w-0 break-words">{label}</span>
         </>
       )}
     </Button>

--- a/src/components/page-builder/lead-card-carousel/LeadCardCarouselView.tsx
+++ b/src/components/page-builder/lead-card-carousel/LeadCardCarouselView.tsx
@@ -650,7 +650,7 @@ export function LeadCardCarouselView(props: LeadCardCarouselModel & { onClose?: 
           </div>
           
           {/* Task Progress Section */}
-          <CardContent className={`flex flex-col gap-8 p-4 bg-white ${actionButtonsVisible && postCallActions.length > 0 ? 'pb-28 md:pb-24' : 'pb-4'}`} style={bodyFont}>
+          <CardContent className={`flex flex-col gap-8 p-4 bg-white ${actionButtonsVisible && postCallActions.length > 0 ? 'pb-32 md:pb-28' : 'pb-4'}`} style={bodyFont}>
             <div
               className={cn(
                 "grid gap-6",
@@ -679,18 +679,18 @@ export function LeadCardCarouselView(props: LeadCardCarouselModel & { onClose?: 
         </Card>
       </div>
       
-      {/* FIXED MOBILE ACTION BUTTONS - Spans full width, flex wraps cleanly */}
+      {/* Bottom action bar — sized by left/right inset (do not use w-full with sidebar offset) */}
       {!hideActionBar && actionButtonsVisible && postCallActions.length > 0 && (
         <div 
           className={cn(
-            "z-[100] border-t border-slate-200 bg-white px-3 md:px-6 py-3 md:py-4 shadow-[0_-4px_6px_-1px_rgb(0,0,0,0.05)] w-full",
+            "z-[100] border-t border-slate-200 bg-white px-3 md:px-4 lg:px-6 py-3 md:py-4 shadow-[0_-4px_6px_-1px_rgb(0,0,0,0.05)] box-border",
             isInModal 
-              ? "sticky bottom-0 shrink-0" 
-              : "fixed bottom-0 right-0 left-0 md:left-[var(--sidebar-width,288px)] transition-all duration-200 ease-in-out"
+              ? "sticky bottom-0 shrink-0 w-full" 
+              : "fixed bottom-0 left-0 right-0 md:left-[var(--sidebar-width,288px)] transition-[left] duration-200 ease-in-out"
           )}
           style={isInModal ? { pointerEvents: 'auto' } : undefined}
         >
-          <div className="flex w-full flex-wrap items-center justify-center gap-2 md:gap-3">
+          <div className="grid w-full max-w-full grid-cols-2 gap-2 md:grid-cols-4 md:gap-2 lg:gap-3">
             {postCallActions.map((action) => (
               <LeadActionButton
                 key={action.id}
@@ -700,7 +700,7 @@ export function LeadCardCarouselView(props: LeadCardCarouselModel & { onClose?: 
                 disabled={updating || fetchingNext}
                 loading={Boolean(processingAction === action.loadingKey && updating)}
                 tone={action.tone}
-                className="flex-1 min-w-[calc(50%-0.5rem)] md:min-w-[140px]"
+                className="w-full max-w-full min-w-0"
               />
             ))}
           </div>

--- a/src/components/page-builder/lead-table/LeadTableView.tsx
+++ b/src/components/page-builder/lead-table/LeadTableView.tsx
@@ -462,13 +462,13 @@ export function LeadTableView(props: LeadTableModel) {
                     }}
                   />
                 </div>
-                {/* Action bar fixed in dialog footer - only show when actionButtonsVisible is true AND CallBackModal is not open */}
+                {/* Action bar at bottom of modal — 4 equal columns so Call Back Later stays on-screen */}
                 {actionButtonsVisible && !isCallBackModalOpen && (
-                <div className="shrink-0 border-t border-slate-200 bg-white px-6 py-4 flex flex-wrap items-center gap-3">
+                <div className="shrink-0 border-t border-slate-200 bg-white px-3 md:px-4 lg:px-6 py-3 md:py-4 grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-2 lg:gap-3 w-full max-w-full box-border">
                   <Button
                     type="button"
                     variant="outline"
-                    className="flex-1 min-w-[140px] h-12 rounded-xl gap-2 hover:bg-slate-100 hover:text-slate-900"
+                    className="w-full max-w-full min-w-0 h-auto min-h-12 rounded-xl gap-1.5 md:gap-2 px-2 md:px-2.5 lg:px-3 py-2.5 text-xs md:text-sm !whitespace-normal leading-tight hover:bg-slate-100 hover:text-slate-900"
                     onClick={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
@@ -480,13 +480,13 @@ export function LeadTableView(props: LeadTableModel) {
                       }
                     }}
                   >
-                    <CheckCircle2 className="h-4 w-4" />
-                    Trial Activated
+                    <CheckCircle2 className="h-4 w-4 shrink-0" />
+                    <span className="min-w-0 break-words">Trial Activated</span>
                   </Button>
                   <Button
                     type="button"
                     variant="outline"
-                    className="flex-1 min-w-[140px] h-12 rounded-xl gap-2 hover:bg-slate-100 hover:text-slate-900"
+                    className="w-full max-w-full min-w-0 h-auto min-h-12 rounded-xl gap-1.5 md:gap-2 px-2 md:px-2.5 lg:px-3 py-2.5 text-xs md:text-sm !whitespace-normal leading-tight hover:bg-slate-100 hover:text-slate-900"
                     onClick={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
@@ -498,13 +498,13 @@ export function LeadTableView(props: LeadTableModel) {
                       }
                     }}
                   >
-                    <MessageCircle className="h-4 w-4" />
-                    Not Interested
+                    <MessageCircle className="h-4 w-4 shrink-0" />
+                    <span className="min-w-0 break-words">Not Interested</span>
                   </Button>
                   <Button
                     type="button"
                     variant="outline"
-                    className="flex-1 min-w-[140px] h-12 rounded-xl gap-2 hover:bg-slate-100 hover:text-slate-900"
+                    className="w-full max-w-full min-w-0 h-auto min-h-12 rounded-xl gap-1.5 md:gap-2 px-2 md:px-2.5 lg:px-3 py-2.5 text-xs md:text-sm !whitespace-normal leading-tight hover:bg-slate-100 hover:text-slate-900"
                     onClick={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
@@ -516,13 +516,13 @@ export function LeadTableView(props: LeadTableModel) {
                       }
                     }}
                   >
-                    <AlertCircle className="h-4 w-4" />
-                    Not Connected
+                    <AlertCircle className="h-4 w-4 shrink-0" />
+                    <span className="min-w-0 break-words">Not Connected</span>
                   </Button>
                   <Button
                     type="button"
                     variant="outline"
-                    className="flex-1 min-w-[140px] h-12 rounded-xl gap-2 hover:bg-slate-100 hover:text-slate-900"
+                    className="w-full max-w-full min-w-0 h-auto min-h-12 rounded-xl gap-1.5 md:gap-2 px-2 md:px-2.5 lg:px-3 py-2.5 text-xs md:text-sm !whitespace-normal leading-tight hover:bg-slate-100 hover:text-slate-900"
                     onClick={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
@@ -534,8 +534,8 @@ export function LeadTableView(props: LeadTableModel) {
                       }
                     }}
                   >
-                    <Clock className="h-4 w-4" />
-                    Call Back Later
+                    <Clock className="h-4 w-4 shrink-0" />
+                    <span className="min-w-0 break-words">Call Back Later</span>
                   </Button>
                 </div>
                 )}


### PR DESCRIPTION
Keep all four bottom actions on-screen with the sidebar offset, and pin Close/Save in the Call Back panel so they stay visible on tablet.