### PR TITLE
Keep New Request form values when switching tabs.

### DIFF
--- a/src/components/page-builder/inventory-request-form/draftStorage.test.ts
+++ b/src/components/page-builder/inventory-request-form/draftStorage.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { DEFAULT_DELIVERY_ADDRESS, DEFAULT_DELIVERY_PINCODE } from './constants';
+import {
+  DRAFT_STORAGE_PREFIX,
+  _resetDraftMemoryForTests,
+  clearAllInventoryRequestFormDrafts,
+  clearDraft,
+  isMeaningfulDraft,
+  loadDraft,
+  makeDraftKey,
+  saveDraft,
+  sanitizeDraft,
+} from './draftStorage';
+import { newEmptyItem } from './utils';
+
+afterEach(() => {
+  _resetDraftMemoryForTests();
+  window.sessionStorage.clear();
+});
+
+function sampleDraft(userId: string, projectPurpose: string) {
+  return {
+    userId,
+    projectPurpose,
+    requestCategory: 'Domestic' as const,
+    deliveryPincode: '560001',
+    deliveryAddress: 'Office',
+    items: [{ ...newEmptyItem(), item_name_freeform: 'USB cable', quantity_required: 3 }],
+    priceDraftByItemId: {},
+    persistedAt: Date.now(),
+  };
+}
+
+describe('inventory request form draft storage', () => {
+  const requestorKey = makeDraftKey({
+    userId: 'requestor-1',
+    tenantSlug: 'unmannd',
+    pageId: 'page-1',
+    entityType: 'unmannd_request',
+    variant: 'default',
+  });
+  const otherRequestorKey = makeDraftKey({
+    userId: 'requestor-2',
+    tenantSlug: 'unmannd',
+    pageId: 'page-1',
+    entityType: 'unmannd_request',
+    variant: 'default',
+  });
+  const teamLeadKey = makeDraftKey({
+    userId: 'team-lead-1',
+    tenantSlug: 'unmannd',
+    pageId: 'page-1',
+    entityType: 'unmannd_request',
+    variant: 'default',
+  });
+
+  it('scopes the storage key to the signed-in user', () => {
+    expect(requestorKey.startsWith(DRAFT_STORAGE_PREFIX)).toBe(true);
+    expect(requestorKey).toContain('requestor-1');
+    expect(requestorKey).not.toBe(otherRequestorKey);
+    expect(requestorKey).not.toBe(teamLeadKey);
+    expect(makeDraftKey({ ...{ userId: '', tenantSlug: 'unmannd', pageId: 'page-1', entityType: 'unmannd_request', variant: 'default' } })).toBe('');
+  });
+
+  it('saves and restores filled values after a remount-style load', () => {
+    const item = { ...newEmptyItem(), item_name_freeform: 'USB cable', quantity_required: 3 };
+    saveDraft(requestorKey, {
+      userId: 'requestor-1',
+      projectPurpose: 'Drone build',
+      requestCategory: 'Domestic',
+      deliveryPincode: '560001',
+      deliveryAddress: 'Office',
+      items: [item],
+      priceDraftByItemId: { [item.id]: '1,200' },
+      persistedAt: Date.now(),
+    });
+
+    _resetDraftMemoryForTests();
+    const restored = loadDraft(requestorKey, 'requestor-1');
+    expect(restored?.projectPurpose).toBe('Drone build');
+    expect(restored?.requestCategory).toBe('Domestic');
+    expect(restored?.deliveryPincode).toBe('560001');
+    expect(restored?.items[0]?.item_name_freeform).toBe('USB cable');
+    expect(restored?.items[0]?.quantity_required).toBe(3);
+    expect(restored?.priceDraftByItemId[item.id]).toBe('1,200');
+  });
+
+  it('does not restore one requestor draft for another requestor, team lead, or manager', () => {
+    saveDraft(requestorKey, sampleDraft('requestor-1', 'Secret project'));
+
+    expect(loadDraft(otherRequestorKey, 'requestor-2')).toBeNull();
+    expect(loadDraft(teamLeadKey, 'team-lead-1')).toBeNull();
+    expect(loadDraft(requestorKey, 'requestor-2')).toBeNull();
+    expect(loadDraft(requestorKey, 'team-lead-1')).toBeNull();
+    expect(loadDraft(requestorKey, 'manager-1')).toBeNull();
+    expect(loadDraft(requestorKey, 'requestor-1')?.projectPurpose).toBe('Secret project');
+  });
+
+  it('treats default empty form as not meaningful', () => {
+    expect(
+      isMeaningfulDraft({
+        projectPurpose: '',
+        requestCategory: '',
+        deliveryPincode: DEFAULT_DELIVERY_PINCODE,
+        deliveryAddress: DEFAULT_DELIVERY_ADDRESS,
+        items: [newEmptyItem()],
+      })
+    ).toBe(false);
+  });
+
+  it('treats a typed project or item as meaningful', () => {
+    expect(
+      isMeaningfulDraft({
+        projectPurpose: 'Alpha',
+        requestCategory: '',
+        deliveryPincode: DEFAULT_DELIVERY_PINCODE,
+        deliveryAddress: DEFAULT_DELIVERY_ADDRESS,
+        items: [newEmptyItem()],
+      })
+    ).toBe(true);
+  });
+
+  it('drops expired drafts', () => {
+    const stale = sanitizeDraft({
+      userId: 'requestor-1',
+      projectPurpose: 'Old',
+      requestCategory: 'Domestic',
+      deliveryPincode: '560001',
+      deliveryAddress: 'Office',
+      items: [{ ...newEmptyItem(), item_name_freeform: 'Bolt' }],
+      priceDraftByItemId: {},
+      persistedAt: Date.now() - 25 * 60 * 60 * 1000,
+    });
+    expect(stale).toBeNull();
+  });
+
+  it('clears a draft so the next visit starts empty', () => {
+    saveDraft(requestorKey, sampleDraft('requestor-1', 'Keep me'));
+    clearDraft(requestorKey);
+    expect(loadDraft(requestorKey, 'requestor-1')).toBeNull();
+  });
+
+  it('clears every stored form draft at once', () => {
+    saveDraft(requestorKey, sampleDraft('requestor-1', 'One'));
+    saveDraft(teamLeadKey, sampleDraft('team-lead-1', 'Lead draft'));
+    clearAllInventoryRequestFormDrafts();
+    expect(loadDraft(requestorKey, 'requestor-1')).toBeNull();
+    expect(loadDraft(teamLeadKey, 'team-lead-1')).toBeNull();
+  });
+});

--- a/src/components/page-builder/inventory-request-form/draftStorage.ts
+++ b/src/components/page-builder/inventory-request-form/draftStorage.ts
@@ -1,0 +1,214 @@
+/** Persist New Request form values across in-app tab switches and remounts. */
+
+import { DEFAULT_DELIVERY_ADDRESS, DEFAULT_DELIVERY_PINCODE } from './constants';
+import type { FormItem, RequestCategory } from './types';
+import { newEmptyItem } from './utils';
+
+export const DRAFT_STORAGE_PREFIX = 'bob.inventoryRequestFormDraft.v2';
+const LEGACY_DRAFT_PREFIXES = ['bob.inventoryRequestFormDraft.v1'];
+export const DRAFT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+export type InventoryRequestFormDraft = {
+  userId: string | null;
+  projectPurpose: string;
+  requestCategory: RequestCategory;
+  deliveryPincode: string;
+  deliveryAddress: string;
+  items: FormItem[];
+  priceDraftByItemId: Record<string, string>;
+  persistedAt: number;
+};
+
+export type DraftKeyParts = {
+  /** Required — drafts are private to this user (requestor / TL / manager). */
+  userId: string;
+  tenantSlug?: string | null;
+  pageId?: string | null;
+  entityType: string;
+  variant: string;
+};
+
+const memoryCache = new Map<string, InventoryRequestFormDraft>();
+
+export function makeDraftKey(parts: DraftKeyParts): string {
+  const userId = String(parts.userId || '').trim();
+  if (!userId) return '';
+  return [
+    DRAFT_STORAGE_PREFIX,
+    parts.tenantSlug ?? '',
+    parts.pageId ?? '',
+    parts.entityType,
+    parts.variant,
+    userId,
+  ].join(':');
+}
+
+function itemHasDraftContent(item: FormItem): boolean {
+  return (
+    (item.item_name_freeform ?? '').trim() !== '' ||
+    (item.specifications ?? '').trim() !== '' ||
+    item.quantity_required !== '' ||
+    (item.urgency_level ?? '').trim() !== '' ||
+    (item.vendor ?? '').trim() !== '' ||
+    (item.estimated_cost ?? '') !== '' ||
+    (item.comments ?? '').trim() !== '' ||
+    (item.product_link ?? '').trim() !== '' ||
+    (item.product_image ?? '').trim() !== ''
+  );
+}
+
+export function isMeaningfulDraft(draft: Pick<
+  InventoryRequestFormDraft,
+  'projectPurpose' | 'requestCategory' | 'deliveryPincode' | 'deliveryAddress' | 'items'
+>): boolean {
+  if (draft.projectPurpose.trim()) return true;
+  if (draft.requestCategory) return true;
+  if (draft.deliveryPincode.trim() && draft.deliveryPincode.trim() !== DEFAULT_DELIVERY_PINCODE) {
+    return true;
+  }
+  if (draft.deliveryAddress.trim() && draft.deliveryAddress.trim() !== DEFAULT_DELIVERY_ADDRESS) {
+    return true;
+  }
+  return draft.items.some(itemHasDraftContent);
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : value == null ? '' : String(value);
+}
+
+function sanitizeQuantity(value: unknown): number | '' {
+  if (value === '' || value == null) return '';
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : '';
+}
+
+function sanitizeFormItem(raw: unknown): FormItem | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  const base = newEmptyItem();
+  return {
+    ...base,
+    id: asString(o.id) || base.id,
+    item_name_freeform: asString(o.item_name_freeform),
+    specifications: asString(o.specifications),
+    quantity_required: sanitizeQuantity(o.quantity_required),
+    required_date: asString(o.required_date),
+    product_link: asString(o.product_link),
+    product_image: asString(o.product_image),
+    vendor: asString(o.vendor),
+    estimated_cost: sanitizeQuantity(o.estimated_cost),
+    price_currency: o.price_currency === 'USD' ? 'USD' : 'INR',
+    urgency_level: asString(o.urgency_level),
+    comments: asString(o.comments),
+    price_quotes: Array.isArray(o.price_quotes) ? (o.price_quotes as FormItem['price_quotes']) : [],
+  };
+}
+
+function sanitizePriceDrafts(raw: unknown): Record<string, string> {
+  if (!raw || typeof raw !== 'object') return {};
+  const out: Record<string, string> = {};
+  for (const [id, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === 'string') out[id] = value;
+  }
+  return out;
+}
+
+export function sanitizeDraft(raw: unknown): InventoryRequestFormDraft | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  const persistedAt = typeof o.persistedAt === 'number' ? o.persistedAt : 0;
+  if (persistedAt > 0 && Date.now() - persistedAt > DRAFT_MAX_AGE_MS) return null;
+
+  const category = o.requestCategory;
+  const requestCategory: RequestCategory =
+    category === 'Domestic' || category === 'International' ? category : '';
+
+  const items = Array.isArray(o.items)
+    ? o.items.map(sanitizeFormItem).filter((item): item is FormItem => item != null)
+    : [];
+
+  return {
+    userId: typeof o.userId === 'string' && o.userId ? o.userId : null,
+    projectPurpose: asString(o.projectPurpose),
+    requestCategory,
+    deliveryPincode: asString(o.deliveryPincode) || DEFAULT_DELIVERY_PINCODE,
+    deliveryAddress: asString(o.deliveryAddress) || DEFAULT_DELIVERY_ADDRESS,
+    items: items.length > 0 ? items : [newEmptyItem()],
+    priceDraftByItemId: sanitizePriceDrafts(o.priceDraftByItemId),
+    persistedAt,
+  };
+}
+
+function draftBelongsToOwner(draft: InventoryRequestFormDraft, ownerUserId: string): boolean {
+  return Boolean(draft.userId && ownerUserId && draft.userId === ownerUserId);
+}
+
+export function loadDraft(key: string, ownerUserId: string): InventoryRequestFormDraft | null {
+  if (!key || !ownerUserId) return null;
+
+  const fromMemory = memoryCache.get(key);
+  if (fromMemory) {
+    const fresh = sanitizeDraft(fromMemory);
+    if (fresh && draftBelongsToOwner(fresh, ownerUserId)) return fresh;
+    if (!fresh) memoryCache.delete(key);
+    else return null;
+  }
+
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = sanitizeDraft(JSON.parse(raw));
+    if (!parsed) {
+      window.sessionStorage.removeItem(key);
+      return null;
+    }
+    if (!draftBelongsToOwner(parsed, ownerUserId)) return null;
+    memoryCache.set(key, parsed);
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function saveDraft(key: string, draft: InventoryRequestFormDraft): void {
+  if (!key || !draft.userId) return;
+  memoryCache.set(key, draft);
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(key, JSON.stringify(draft));
+  } catch {
+    // Private mode / quota — in-memory cache still covers in-app tab switches.
+  }
+}
+
+export function clearDraft(key: string): void {
+  memoryCache.delete(key);
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function clearAllInventoryRequestFormDrafts(): void {
+  memoryCache.clear();
+  if (typeof window === 'undefined') return;
+  try {
+    const prefixes = [DRAFT_STORAGE_PREFIX, ...LEGACY_DRAFT_PREFIXES];
+    const keys: string[] = [];
+    for (let i = 0; i < window.sessionStorage.length; i += 1) {
+      const k = window.sessionStorage.key(i);
+      if (k && prefixes.some((prefix) => k.startsWith(prefix))) keys.push(k);
+    }
+    for (const k of keys) window.sessionStorage.removeItem(k);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Test-only: drop in-memory drafts without touching sessionStorage. */
+export function _resetDraftMemoryForTests(): void {
+  memoryCache.clear();
+}

--- a/src/components/page-builder/inventory-request-form/useInventoryRequestForm.ts
+++ b/src/components/page-builder/inventory-request-form/useInventoryRequestForm.ts
@@ -14,7 +14,7 @@ import {
 import { fetchDistinctFieldValues } from '@/components/page-builder/dispatch/fetchDistinctFieldValues';
 import { supabase } from '@/lib/supabase';
 import { getTenantIdFromJWT, getRoleIdFromJWT } from '@/lib/auth/jwt';
-import { getEffectiveToken, fetchPagesForRole } from '@/lib/auth/spoof';
+import { getEffectiveToken, fetchPagesForRole, useSpoofUserId } from '@/lib/auth/spoof';
 
 import {
   RECORDS_URL,
@@ -31,6 +31,7 @@ import type {
   RequestCategory,
   VendorOption,
 } from './types';
+import type { InventoryRequestFormDraft } from './draftStorage';
 import {
   normalizeIndianPincode,
   normalizeProductName,
@@ -38,6 +39,13 @@ import {
   toVendorStorageName,
   newEmptyItem,
 } from './utils';
+import {
+  clearDraft,
+  isMeaningfulDraft,
+  loadDraft,
+  makeDraftKey,
+  saveDraft,
+} from './draftStorage';
 
 const normalizePageName = (name: string) => name.trim().toLowerCase().replace(/\s+/g, ' ');
 
@@ -135,6 +143,8 @@ export function useInventoryRequestForm({
 }: InventoryRequestFormProps) {
   const isProcurement = variant === 'procurement';
   const { user, session } = useAuth();
+  const spoofUserId = useSpoofUserId();
+  const draftOwnerId = spoofUserId || user?.id || null;
   const navigate = useNavigate();
   const { tenantSlug, pageId: currentPageId } = useParams<{
     tenantSlug?: string;
@@ -142,6 +152,15 @@ export function useInventoryRequestForm({
   }>();
 
   const entityType = config?.entityType ?? 'inventory_request';
+  const draftKey = draftOwnerId
+    ? makeDraftKey({
+        userId: draftOwnerId,
+        tenantSlug,
+        pageId: currentPageId,
+        entityType,
+        variant: isProcurement ? 'procurement' : 'default',
+      })
+    : '';
   // Navy chrome for Unmannd: procurement form, unmannd entity, or unmannd tenant slug.
   const useNavyTheme =
     isProcurement ||
@@ -189,6 +208,13 @@ export function useInventoryRequestForm({
   const [focusedVendorId, setFocusedVendorId] = useState<string | null>(null);
   const [vendorQuery, setVendorQuery] = useState<string>('');
   const [vendorSuggestionsOpen, setVendorSuggestionsOpen] = useState(false);
+  const [draftHydrated, setDraftHydrated] = useState(false);
+  const appliedOwnerIdRef = useRef<string | null>(null);
+  const snapshotRef = useRef<(InventoryRequestFormDraft & { key: string }) | null>(null);
+  const persistTimerRef = useRef<number | null>(null);
+  const skipPersistRef = useRef(false);
+  const userIdRef = useRef(draftOwnerId);
+  userIdRef.current = draftOwnerId;
 
   const requesterDisplay =
     requesterNameFromMembership ||
@@ -235,6 +261,124 @@ export function useInventoryRequestForm({
   useEffect(() => {
     void loadProjectSuggestions();
   }, [loadProjectSuggestions]);
+
+  const applyEmptyForm = useCallback(() => {
+    setProjectPurpose('');
+    setRequestCategory('');
+    setDeliveryPincode(DEFAULT_DELIVERY_PINCODE);
+    setDeliveryAddress(DEFAULT_DELIVERY_ADDRESS);
+    setItems([newEmptyItem()]);
+    setPriceDraftByItemId({});
+    setFieldShakeNonce({});
+  }, []);
+
+  const applyDraftToForm = useCallback((draft: InventoryRequestFormDraft) => {
+    setProjectPurpose(draft.projectPurpose);
+    setRequestCategory(draft.requestCategory);
+    setDeliveryPincode(draft.deliveryPincode || DEFAULT_DELIVERY_PINCODE);
+    setDeliveryAddress(draft.deliveryAddress || DEFAULT_DELIVERY_ADDRESS);
+    setItems(draft.items.length > 0 ? draft.items : [newEmptyItem()]);
+    setPriceDraftByItemId(draft.priceDraftByItemId ?? {});
+    setFieldShakeNonce({});
+  }, []);
+
+  // Only record a snapshot once this owner's fields are on screen, so we never
+  // write requestor A's values into team lead / manager / another requestor's slot.
+  if (appliedOwnerIdRef.current === draftOwnerId && draftKey && draftOwnerId) {
+    snapshotRef.current = {
+      key: draftKey,
+      userId: draftOwnerId,
+      projectPurpose,
+      requestCategory,
+      deliveryPincode,
+      deliveryAddress,
+      items,
+      priceDraftByItemId,
+      persistedAt: Date.now(),
+    };
+  }
+
+  useEffect(() => {
+    skipPersistRef.current = true;
+
+    const prev = snapshotRef.current;
+    if (prev?.userId && prev.key && draftOwnerId && prev.userId !== draftOwnerId) {
+      const { key: prevKey, ...prevDraft } = prev;
+      if (isMeaningfulDraft(prevDraft)) {
+        saveDraft(prevKey, { ...prevDraft, persistedAt: Date.now() });
+      } else {
+        clearDraft(prevKey);
+      }
+      snapshotRef.current = null;
+    }
+
+    if (!draftOwnerId || !draftKey) {
+      appliedOwnerIdRef.current = null;
+      applyEmptyForm();
+      setDraftHydrated(false);
+      return;
+    }
+
+    const draft = loadDraft(draftKey, draftOwnerId);
+    if (draft) applyDraftToForm(draft);
+    else applyEmptyForm();
+    appliedOwnerIdRef.current = draftOwnerId;
+    setDraftHydrated(true);
+  }, [draftKey, draftOwnerId, applyEmptyForm, applyDraftToForm]);
+
+  useEffect(() => {
+    if (!draftHydrated) return;
+    if (skipPersistRef.current) {
+      skipPersistRef.current = false;
+      return;
+    }
+    if (!draftOwnerId || !draftKey) return;
+    if (appliedOwnerIdRef.current !== draftOwnerId) return;
+
+    const persist = () => {
+      persistTimerRef.current = null;
+      const snap = snapshotRef.current;
+      if (!snap?.key || !snap.userId) return;
+      if (snap.userId !== userIdRef.current) return;
+      const { key, ...draft } = snap;
+      if (!isMeaningfulDraft(draft)) {
+        clearDraft(key);
+        return;
+      }
+      saveDraft(key, { ...draft, persistedAt: Date.now() });
+    };
+    if (persistTimerRef.current != null) {
+      window.clearTimeout(persistTimerRef.current);
+    }
+    persistTimerRef.current = window.setTimeout(persist, 250);
+    return () => {
+      if (persistTimerRef.current != null) {
+        window.clearTimeout(persistTimerRef.current);
+        persistTimerRef.current = null;
+      }
+      if (!skipPersistRef.current && userIdRef.current) persist();
+    };
+  }, [
+    draftHydrated,
+    draftKey,
+    draftOwnerId,
+    projectPurpose,
+    requestCategory,
+    deliveryPincode,
+    deliveryAddress,
+    items,
+    priceDraftByItemId,
+  ]);
+
+  const discardDraft = useCallback(() => {
+    skipPersistRef.current = true;
+    if (persistTimerRef.current != null) {
+      window.clearTimeout(persistTimerRef.current);
+      persistTimerRef.current = null;
+    }
+    snapshotRef.current = null;
+    if (draftKey) clearDraft(draftKey);
+  }, [draftKey]);
 
   const rememberProjectSuggestion = useCallback((value: string) => {
     const trimmed = value.trim();
@@ -773,6 +917,7 @@ export function useInventoryRequestForm({
         );
       }
       rememberProjectSuggestion(projectPurpose);
+      discardDraft();
 
       const navigateAfterCreate = async () => {
         // After create: prefer My Requests for all roles (TL / PM included); All Requests as fallback for approvers.
@@ -830,13 +975,7 @@ export function useInventoryRequestForm({
 
         if (!redirected) {
           setShowSubmitSuccess(false);
-          setItems([newEmptyItem()]);
-          setProjectPurpose('');
-          setRequestCategory('');
-          setDeliveryPincode(DEFAULT_DELIVERY_PINCODE);
-          setDeliveryAddress(DEFAULT_DELIVERY_ADDRESS);
-          setPriceDraftByItemId({});
-          setFieldShakeNonce({});
+          applyEmptyForm();
         }
       };
 
@@ -862,16 +1001,11 @@ export function useInventoryRequestForm({
   };
 
   const handleClear = () => {
-    setItems([newEmptyItem()]);
+    applyEmptyForm();
     setAddVendorForItemId(null);
     setNewVendorName('');
     setNewVendorLink('');
-    setPriceDraftByItemId({});
-    setProjectPurpose('');
-    setRequestCategory('');
-    setDeliveryPincode(DEFAULT_DELIVERY_PINCODE);
-    setDeliveryAddress(DEFAULT_DELIVERY_ADDRESS);
-    setFieldShakeNonce({});
+    discardDraft();
     toast.success('Form cleared.');
   };
 

--- a/src/lib/auth/deletedUserSession.ts
+++ b/src/lib/auth/deletedUserSession.ts
@@ -12,6 +12,7 @@ import { authService, membershipService } from '@/lib/api';
 import { signOutAndClearSession } from '@/lib/auth/authSessionService';
 import { supabase } from '@/lib/supabase';
 import type { User } from '@supabase/supabase-js';
+import { clearAllInventoryRequestFormDrafts } from '@/components/page-builder/inventory-request-form/draftStorage';
 
 const ACCESS_CACHE_KEY = 'pyro_access_check';
 const SESSION_CHECK_MS = 15_000;
@@ -22,6 +23,7 @@ export function clearLocalAuthCaches(): void {
   try {
     sessionStorage.removeItem(ACCESS_CACHE_KEY);
     sessionStorage.removeItem('ticketCarouselState');
+    clearAllInventoryRequestFormDrafts();
   } catch {
     /* ignore */
   }


### PR DESCRIPTION
Drafts are stored per user so one requestor’s in-progress form is not shown to another requestor, team lead, or manager, and they are cleared on logout.